### PR TITLE
Unpin internal crypto lib, add cargo lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ data-plane/*.pem
 e2e-tests/testing-certs/*
 e2e-tests/mtls-testing-certs/ca/*
 !e2e-tests/mtls-testing-certs/ca/generate-certs.sh
+e2e-tests/mock-crypto/Cargo.lock
 e2e-tests/health-check-response.txt
 ci/**/node_modules
 .vscode

--- a/e2e-tests/mock-crypto/Cargo.toml
+++ b/e2e-tests/mock-crypto/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-crypto = { version = "=1.0.0-beta.6", registry="evervault-rust-libraries", features=["vendored-openssl"] }
+rust-crypto = { version = "1.0.0-beta.6", registry="evervault-rust-libraries", features=["vendored-openssl"] }
 axum = "0.5.16"
 axum-server = { version = "0.4.2", features = ["tls-rustls"] }
 tokio = {version="1.24.2", features=["macros", "rt-multi-thread"]}

--- a/e2e-tests/mock-crypto/Cargo.toml
+++ b/e2e-tests/mock-crypto/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-crypto = { version = "1.0.0-beta.6", registry="evervault-rust-libraries", features=["vendored-openssl"] }
+rust-crypto = { version = "=1.0.0-beta.8", registry="evervault-rust-libraries", features=["vendored-openssl"] }
 axum = "0.5.16"
 axum-server = { version = "0.4.2", features = ["tls-rustls"] }
 tokio = {version="1.24.2", features=["macros", "rt-multi-thread"]}


### PR DESCRIPTION
# Why
Prevent tracking of cargo lock and allow internal crypto lib to pull newer versions

# How
Unpin crypto lib, add cargo lock to gitignore
