### PR TITLE
[SPE-542] Don't send trx logs when in debug mode and trx_logging is switched off

### DIFF
--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -105,8 +105,6 @@ where
                                         if let Err(e) = tx_for_req.send(LogHandlerMessage::new_log_message(ctx)) {
                                             println!("Failed to send transaction context to log handler. err: {e}")
                                         }
-                                    } else {
-                                        ctx.record_trx();
                                     }
                                 },
                                 Err(e) => {


### PR DESCRIPTION
# Why
Trx logs shouldn't be logged when trx_logging is disabled but debug mode is on.

# How
Stop logging trx_logs in the enclave when trx_logging turned off. This also means the control plane can validate trx logs before been shipped to ES.
