### PR TITLE
[SPE-541] Validate cage and ev tenant details before logging a trx context

### DIFF
--- a/control-plane/src/configuration.rs
+++ b/control-plane/src/configuration.rs
@@ -38,6 +38,26 @@ pub fn get_aws_region() -> Region {
         .unwrap_or(Ok(Region::UsEast1))
         .expect("Expected AWS Region to be set under AWS_PROFILE")
 }
+#[derive(Clone)]
+pub struct CageContext {
+    pub cage_uuid: String,
+    pub cage_version: String,
+    pub cage_name: String,
+    pub app_uuid: String,
+    pub team_uuid: String,
+}
+
+impl CageContext {
+    pub fn from_env_vars() -> CageContext {
+        CageContext {
+            cage_uuid: get_cage_uuid(),
+            cage_version: get_cage_version(),
+            cage_name: get_cage_name(),
+            app_uuid: get_app_uuid(),
+            team_uuid: get_team_uuid(),
+        }
+    }
+}
 
 pub fn get_cage_uuid() -> String {
     std::env::var("CAGE_UUID").expect("CAGE_UUID is not set in env")

--- a/shared/src/logging.rs
+++ b/shared/src/logging.rs
@@ -32,10 +32,10 @@ pub struct TrxContext {
     response_code: Option<String>,
     #[builder(default)]
     status_group: Option<String>,
-    cage_name: String,
-    cage_uuid: String,
-    app_uuid: String,
-    team_uuid: String,
+    pub cage_name: String,
+    pub cage_uuid: String,
+    pub app_uuid: String,
+    pub team_uuid: String,
     #[builder(default)]
     n_decrypted_fields: Option<u32>,
     #[builder(default)]


### PR DESCRIPTION
# Why
A cage could override the trx context ev tenant details. We need to validate them in the control plane.

# How
Introduce a cage_context to the control plane instead of pulling env vars on every read. 

Use this cage context to check app, team, cage uuid and name when loggin trx context. 
