### PR TITLE
Remove uuids from crypto calls

### DIFF
--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -14,7 +14,7 @@ use hyper::{
 use crate::base_tls_client::ClientError;
 use crate::e3client::{CryptoRequest, CryptoResponse, E3Client};
 use crate::error::Error;
-use crate::{CageContext, CageContextError};
+use crate::CageContextError;
 
 #[cfg(feature = "enclave")]
 use super::attest;
@@ -113,10 +113,9 @@ impl CryptoApi {
     async fn build_request(&mut self, req: Request<Body>) -> Result<CryptoRequest, CryptoApiError> {
         let (_, body) = req.into_parts();
         let body_bytes = hyper::body::to_bytes(body).await?;
-        let cage_context = CageContext::get()?;
         let body: Value =
             serde_json::from_slice(&body_bytes).map_err(|_| CryptoApiError::SerializationError)?;
-        let payload = CryptoRequest::from((body, &cage_context));
+        let payload = CryptoRequest::new(body);
         Ok(payload)
     }
 

--- a/data-plane/src/e3client/mod.rs
+++ b/data-plane/src/e3client/mod.rs
@@ -203,8 +203,6 @@ impl EncryptedDataEntry {
 
 #[derive(Serialize, Deserialize)]
 pub struct DecryptRequest {
-    team_uuid: String,
-    app_uuid: String,
     data: Vec<EncryptedDataEntry>,
 }
 
@@ -216,21 +214,15 @@ impl DecryptRequest {
     }
 }
 
-impl std::convert::From<(Vec<EncryptedDataEntry>, &crate::CageContext)> for DecryptRequest {
-    fn from((val, context): (Vec<EncryptedDataEntry>, &crate::CageContext)) -> Self {
-        Self {
-            data: val,
-            team_uuid: context.team_uuid().to_string(),
-            app_uuid: context.app_uuid().to_string(),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct CryptoRequest {
-    pub team_uuid: String,
-    pub app_uuid: String,
     pub data: Value,
+}
+
+impl CryptoRequest {
+    pub fn new(data: Value) -> CryptoRequest {
+        CryptoRequest { data }
+    }
 }
 
 impl E3Payload for CryptoRequest {}
@@ -243,15 +235,6 @@ impl CryptoRequest {
     }
 }
 
-impl std::convert::From<(Value, &crate::CageContext)> for CryptoRequest {
-    fn from((val, context): (Value, &crate::CageContext)) -> Self {
-        Self {
-            data: val,
-            team_uuid: context.team_uuid().to_string(),
-            app_uuid: context.app_uuid().to_string(),
-        }
-    }
-}
 pub trait E3Payload: Sized + Serialize {
     fn try_into_body(self) -> Result<hyper::Body, E3Error> {
         Ok(hyper::Body::from(serde_json::to_vec(&self)?))

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -4,7 +4,7 @@ use std::{fs::File, io::Write};
 use crate::cert_provisioner_client::CertProvisionerClient;
 #[cfg(not(feature = "tls_termination"))]
 use crate::config_client::ConfigClient;
-use crate::{base_tls_client::ClientError, CageContext, CageContextError};
+use crate::{base_tls_client::ClientError, CageContextError};
 use hyper::header::InvalidHeaderValue;
 use serde_json::json;
 use shared::server::config_server::requests::Secret;
@@ -60,14 +60,10 @@ impl Environment {
 
         let mut plaintext_env = plaintext_env;
 
-        let cage_context = CageContext::get()?;
-
         if !encrypted_env.is_empty() {
             let e3_response: CryptoResponse = self
                 .e3_client
                 .decrypt(CryptoRequest {
-                    app_uuid: cage_context.app_uuid.clone(),
-                    team_uuid: cage_context.team_uuid.clone(),
                     data: json!(encrypted_env.clone()),
                 })
                 .await?;

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -4,6 +4,8 @@ use std::{fs::File, io::Write};
 use crate::cert_provisioner_client::CertProvisionerClient;
 #[cfg(not(feature = "tls_termination"))]
 use crate::config_client::ConfigClient;
+#[cfg(not(feature = "tls_termination"))]
+use crate::CageContext;
 use crate::{base_tls_client::ClientError, CageContextError};
 use hyper::header::InvalidHeaderValue;
 use serde_json::json;
@@ -79,8 +81,6 @@ impl Environment {
 
     #[cfg(not(feature = "tls_termination"))]
     pub async fn init_without_certs(self) -> Result<(), EnvError> {
-        use shared::server::config_server::routes::ConfigServerPath;
-
         println!("Initializing env without TLS termination, sending request to control plane for cert provisioner token.");
         let token = self.config_client.get_cert_token().await.unwrap().token();
         let cert_response = self.cert_provisioner_client.get_secrets(token).await?;

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -3,10 +3,10 @@ use super::http::ContentEncoding;
 use super::tls::TlsServerBuilder;
 
 use crate::base_tls_client::ClientError;
+use crate::e3client::DecryptRequest;
 use crate::e3client::{self, AuthRequest, E3Client};
 use crate::error::{AuthError, Result};
 use crate::{CageContext, CAGE_CONTEXT};
-use crate::e3client::DecryptRequest;
 
 use crate::utils::trx_handler::{start_log_handler, LogHandlerMessage};
 
@@ -258,7 +258,8 @@ pub async fn handle_standard_request(
 
     let mut bytes_vec = request_bytes.to_vec();
     if !decryption_payload.is_empty() {
-        let request_payload = e3client::CryptoRequest::new(serde_json::Value::Array(decryption_payload));
+        let request_payload =
+            e3client::CryptoRequest::new(serde_json::Value::Array(decryption_payload));
         let decrypted: DecryptRequest = match e3_client
             .decrypt_with_retries(2, request_payload)
             .await

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -3,9 +3,10 @@ use super::http::ContentEncoding;
 use super::tls::TlsServerBuilder;
 
 use crate::base_tls_client::ClientError;
-use crate::e3client::{self, AuthRequest, DecryptRequest, E3Client};
+use crate::e3client::{self, AuthRequest, E3Client};
 use crate::error::{AuthError, Result};
 use crate::{CageContext, CAGE_CONTEXT};
+use crate::e3client::DecryptRequest;
 
 use crate::utils::trx_handler::{start_log_handler, LogHandlerMessage};
 
@@ -221,7 +222,6 @@ async fn handle_incoming_request(
             compression,
             customer_port,
             e3_client,
-            &cage_context,
             trx_context,
         )
         .await
@@ -233,7 +233,6 @@ pub async fn handle_standard_request(
     _compression: Option<super::http::ContentEncoding>,
     customer_port: u16,
     e3_client: Arc<E3Client>,
-    cage_context: &CageContext,
     trx_context: &mut TrxContextBuilder,
 ) -> Response<Body> {
     let (mut req_info, req_body) = req_parts;
@@ -259,10 +258,7 @@ pub async fn handle_standard_request(
 
     let mut bytes_vec = request_bytes.to_vec();
     if !decryption_payload.is_empty() {
-        let request_payload = e3client::CryptoRequest::from((
-            serde_json::Value::Array(decryption_payload),
-            cage_context,
-        ));
+        let request_payload = e3client::CryptoRequest::new(serde_json::Value::Array(decryption_payload));
         let decrypted: DecryptRequest = match e3_client
             .decrypt_with_retries(2, request_payload)
             .await

--- a/e2e-tests/mock-crypto/src/main.rs
+++ b/e2e-tests/mock-crypto/src/main.rs
@@ -161,8 +161,6 @@ async fn attestation_handler() -> Result<Vec<u8>, Infallible> {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct RequestPayload {
-  app_uuid: String,
-  team_uuid: String,
   data: Value
 }
 

--- a/e2e-tests/run-all-feature-tests.sh
+++ b/e2e-tests/run-all-feature-tests.sh
@@ -17,7 +17,7 @@ cd e2e-tests && npm install && cd ..
 if [[ -z "${CI}" ]];
 then
   cd ./e2e-tests/mock-crypto
-  cargo build --release --target x86_64-unknown-linux-musl
+  cargo build --release --target x86_64-unknown-linux-musl -Z registry-auth
   cd ../..
 fi
 


### PR DESCRIPTION
# Why
We use the uuids provided in the token for authentication and the uuids aren't needed in E3

# How
Remove
