### PR TITLE
Enforce allowlist in data plane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV CONTROL_PLANE_SERVICE_PATH=/etc/service/control-plane
 ENV START_EV_SERVICES_PATH=/etc/service/ev-services-entrypoint
 ENV DATA_PLANE_HEALTH_CHECKS=true
 ENV EV_API_KEY_AUTH=true
+ENV EGRESS_ALLOW_LIST=jsonplaceholder.typicode.com
 
 EXPOSE 443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CONTROL_PLANE_SERVICE_PATH=/etc/service/control-plane
 ENV START_EV_SERVICES_PATH=/etc/service/ev-services-entrypoint
 ENV DATA_PLANE_HEALTH_CHECKS=true
 ENV EV_API_KEY_AUTH=true
-ENV EGRESS_ALLOW_LIST=jsonplaceholder.typicode.com
+ENV EV_EGRESS_ALLOW_LIST=jsonplaceholder.typicode.com
 
 EXPOSE 443
 

--- a/data-plane/src/configuration.rs
+++ b/data-plane/src/configuration.rs
@@ -31,21 +31,22 @@ pub fn get_egress_ports() -> Vec<u16> {
 
 pub fn get_egress_allow_list() -> EgressDomains {
     let domain_str = std::env::var("EGRESS_ALLOW_LIST").unwrap_or("".to_string());
-    let domains: Vec<String> = domain_str
+    let (wildcard, exact): (Vec<String>, Vec<String>) = domain_str
         .split(',')
         .map(|domain| domain.to_string())
-        .collect();
-    let (wildcard, exact): (Vec<String>, Vec<String>) = domains
-        .clone()
-        .into_iter()
         .partition(|domain| domain.starts_with("*."));
     let wildcard_stripped = wildcard
         .iter()
-        .filter_map(|w| w.strip_prefix("*.").map(|domain| domain.to_string()))
+        .filter_map(|wc| wc.strip_prefix('*').map(|domain| domain.to_string()))
         .collect();
+    let exact_backwards_compat = if exact == vec![""] {
+        vec!["*".to_string()]
+    } else {
+        exact
+    };
     EgressDomains {
         wildcard: wildcard_stripped,
-        exact,
+        exact: exact_backwards_compat,
     }
 }
 
@@ -57,19 +58,44 @@ pub struct EgressDomains {
 
 #[cfg(test)]
 mod tests {
-    use crate::{configuration::{get_egress_allow_list, EgressDomains}};
+    use crate::configuration::{get_egress_allow_list, EgressDomains};
 
     #[test]
     fn test_valid_all_domains() {
         std::env::set_var("EGRESS_ALLOW_LIST", "*");
         let egress = get_egress_allow_list();
-        assert_eq!(egress, EgressDomains { exact: vec!["*".to_string()], wildcard: vec![]})
+        assert_eq!(
+            egress,
+            EgressDomains {
+                exact: vec!["*".to_string()],
+                wildcard: vec![]
+            }
+        )
     }
 
     #[test]
     fn test_wildcard_and_exact() {
         std::env::set_var("EGRESS_ALLOW_LIST", "*.evervault.com,google.com");
         let egress = get_egress_allow_list();
-        assert_eq!(egress, EgressDomains { exact: vec!["google.com".to_string()], wildcard: vec!["evervault.com".to_string()]})
+        assert_eq!(
+            egress,
+            EgressDomains {
+                exact: vec!["google.com".to_string()],
+                wildcard: vec![".evervault.com".to_string()]
+            }
+        )
+    }
+
+    #[test]
+    fn test_backwards_compat() {
+        std::env::set_var("EGRESS_ALLOW_LIST", "");
+        let egress = get_egress_allow_list();
+        assert_eq!(
+            egress,
+            EgressDomains {
+                exact: vec!["*".to_string()],
+                wildcard: vec![]
+            }
+        )
     }
 }

--- a/data-plane/src/configuration.rs
+++ b/data-plane/src/configuration.rs
@@ -28,3 +28,11 @@ pub fn get_egress_ports() -> Vec<u16> {
         })
         .collect()
 }
+
+pub fn get_egress_allow_list() -> Vec<String> {
+    let domain_str = std::env::var("EGRESS_ALLOW_LIST").unwrap_or("".to_string());
+    domain_str
+        .split(',')
+        .map(|domain| domain.to_string())
+        .collect()
+}

--- a/data-plane/src/configuration.rs
+++ b/data-plane/src/configuration.rs
@@ -29,10 +29,21 @@ pub fn get_egress_ports() -> Vec<u16> {
         .collect()
 }
 
-pub fn get_egress_allow_list() -> Vec<String> {
+pub fn get_egress_allow_list() -> EgressDomains {
     let domain_str = std::env::var("EGRESS_ALLOW_LIST").unwrap_or("".to_string());
-    domain_str
+    let domains: Vec<String> = domain_str
         .split(',')
         .map(|domain| domain.to_string())
-        .collect()
+        .collect();
+    let (wildcard, exact): (Vec<String>, Vec<String>) = domains
+        .clone()
+        .into_iter()
+        .partition(|domain| domain.starts_with("*."));
+    EgressDomains { wildcard, exact }
+}
+
+#[derive(Clone)]
+pub struct EgressDomains {
+    pub wildcard: Vec<String>,
+    pub exact: Vec<String>,
 }

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -78,9 +78,7 @@ impl EgressProxy {
             .iter()
             .any(|wildcard| hostname.ends_with(wildcard));
 
-        if allowed_domains.exact.contains(&hostname)
-            || allowed_domains.exact.contains(&"*".to_string())
-            || valid_wildcard
+        if allowed_domains.exact.contains(&hostname) || allowed_domains.allow_all || valid_wildcard
         {
             Ok(())
         } else {
@@ -141,8 +139,9 @@ mod tests {
     #[test]
     fn test_valid_all_domains() {
         let egress_domains = EgressDomains {
-            exact: vec!["*".to_string()],
+            exact: vec![],
             wildcard: vec![],
+            allow_all: true,
         };
         assert_eq!(
             EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
@@ -154,6 +153,7 @@ mod tests {
         let egress_domains = EgressDomains {
             exact: vec!["app.evervault.com".to_string()],
             wildcard: vec![],
+            allow_all: false,
         };
         assert_eq!(
             EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
@@ -165,6 +165,7 @@ mod tests {
         let egress_domains = EgressDomains {
             exact: vec![],
             wildcard: vec!["evervault.com".to_string()],
+            allow_all: false,
         };
         assert_eq!(
             EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
@@ -176,6 +177,7 @@ mod tests {
         let egress_domains = EgressDomains {
             exact: vec![],
             wildcard: vec!["evervault.com".to_string()],
+            allow_all: false,
         };
         let result = EgressProxy::check_allow_list("google.com".to_string(), egress_domains);
         assert!(matches!(result, Err(EgressDomainNotAllowed(_))));

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -29,7 +29,11 @@ impl EgressProxy {
 
         loop {
             if let Ok(stream) = server.accept().await {
-                tokio::spawn(Self::handle_egress_connection(stream, port, allowed_domains.clone()   ));
+                tokio::spawn(Self::handle_egress_connection(
+                    stream,
+                    port,
+                    allowed_domains.clone(),
+                ));
             }
         }
         #[allow(unreachable_code)]
@@ -67,7 +71,7 @@ impl EgressProxy {
         Ok(Some(destination))
     }
 
-    fn check_allow_list(hostname: String, allowed_domains: Vec<String>) -> Result<(), DNSError>{
+    fn check_allow_list(hostname: String, allowed_domains: Vec<String>) -> Result<(), DNSError> {
         if allowed_domains.contains(&hostname) {
             Ok(())
         } else {
@@ -78,7 +82,7 @@ impl EgressProxy {
     async fn handle_egress_connection<T: AsyncRead + AsyncWrite + Unpin>(
         mut external_stream: T,
         port: u16,
-        allowed_domains: Vec<String>
+        allowed_domains: Vec<String>,
     ) -> Result<(), DNSError> {
         let mut buf = vec![0u8; 4096];
 

--- a/data-plane/src/dns/error.rs
+++ b/data-plane/src/dns/error.rs
@@ -18,4 +18,6 @@ pub enum DNSError {
     TlsParseError(String),
     #[error("Could not find a hostname in the TLS hello message. Perhaps SNI is not being used.")]
     NoHostnameFound,
+    #[error("Attempt to make request against domain that isn't allowed for egress {0}")]
+    EgressDomainNotAllowed(String),
 }

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use crate::e3client::{CryptoRequest, CryptoResponse, E3Client};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error)] 
 pub enum EnvError {
     #[error("{0}")]
     Crypto(String),

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use crate::e3client::{CryptoRequest, CryptoResponse, E3Client};
 
-#[derive(Debug, Error)] 
+#[derive(Debug, Error)]
 pub enum EnvError {
     #[error("{0}")]
     Crypto(String),

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -65,7 +65,11 @@ async fn start(data_plane_port: u16) {
     StatsClient::init();
     let ports = configuration::get_egress_ports();
     let allowed_domains = configuration::get_egress_allow_list();
-    let egress_proxies = join_all(ports.into_iter().map(|port |EgressProxy::listen(port, allowed_domains.clone())));
+    let egress_proxies = join_all(
+        ports
+            .into_iter()
+            .map(|port| EgressProxy::listen(port, allowed_domains.clone())),
+    );
 
     let (_, dns_result, e3_api_result, egress_results, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -64,8 +64,8 @@ async fn start(data_plane_port: u16) {
 
     StatsClient::init();
     let ports = configuration::get_egress_ports();
-
-    let egress_proxies = join_all(ports.into_iter().map(EgressProxy::listen));
+    let allowed_domains = configuration::get_egress_allow_list();
+    let egress_proxies = join_all(ports.into_iter().map(|port |EgressProxy::listen(port, allowed_domains.clone())));
 
     let (_, dns_result, e3_api_result, egress_results, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),

--- a/e2e-tests/customerProcess.js
+++ b/e2e-tests/customerProcess.js
@@ -28,6 +28,15 @@ app.get('/egress', async (req, res) => {
   }
 })
 
+app.get('/egressBanned', async (req, res) => {
+  try {
+    const result = await axios.get("https://evervault.com")
+    res.send({...result.data})
+  } catch (e) {
+    res.status(500).send(e)
+  }
+})
+
 async function encrypt(payload) {
   const result = await axios.post("http://127.0.0.1:9999/encrypt", payload, { headers: { 'api-key': 'placeholder' } });
   return result.data;

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -10,7 +10,6 @@ describe('POST data to enclave', () => {
         })
     });
     it('enclave responds and echos back body', () => {
-        console.log('Sending post request to enclave');
         return allowAllCerts.post('https://cage.localhost:443/hello',{ secret: 'ev:123' }, { headers: { 'api-key': 'placeholder' } }).then((result) => {
             console.log('Post request sent to the enclave');
             expect(result.data).to.deep.equal({ response: 'Hello from enclave',  secret: 'ev:123'});
@@ -20,10 +19,9 @@ describe('POST data to enclave', () => {
         });
     });
 
-    it('calls out to the internet', () => {
+    it('calls out to the internet for allowed domain', () => {
         console.log('Sending get request to the enclave');
         return allowAllCerts.get('https://cage.localhost:443/egress', { headers: { 'api-key': 'placeholder' } }).then((result) => {
-            console.log('Get request sent to the enclave');
             expect(result.data).to.deep.equal({
                 userId :1,
                 id:1,
@@ -32,6 +30,15 @@ describe('POST data to enclave', () => {
         }).catch((err) => {
           console.error(err);
           throw err;
+        });
+    });
+
+    it('calls out to the internet for banned domain', () => {
+        console.log('Sending get request to the enclave');
+        return allowAllCerts.get('https://cage.localhost:443/egressBanned', { headers: { 'api-key': 'placeholder' } }).then((result) => {
+            throw Error("Egress request should have failed for banned domain")
+        }).catch((err) => {
+          expect(err.response.data.message).to.deep.equal("Client network socket disconnected before secure TLS connection was established")
         });
     });
 


### PR DESCRIPTION
# Why
Add egress allowlist to the data plane so that attempts through the egress proxy fail if they are not allowlisted.
Enforcing it in the data plane first so it will be included in attestation. Later on it will be in the control plane too.

# How
- Default behaviour to allow all egress if no settings present to allow backwards compatibility for the moment (*)
- Allow exact domain matching or wildcard eg. app.evervault.com or *.evervault.com
