### PR TITLE
Remove unused metrics

### DIFF
--- a/data-plane/src/stats_client.rs
+++ b/data-plane/src/stats_client.rs
@@ -89,12 +89,8 @@ impl StatsClient {
         if let Ok(context) = CageContext::get() {
             publish_gauge!("memory.total", mem_info.total as f64, context);
             publish_gauge!("memory.avail", mem_info.avail as f64, context);
-            publish_gauge!("memory.free", mem_info.total as f64, context);
-
             publish_gauge!("cpu.cores", cpu_num as f64, context);
             publish_gauge!("cpu.one", cpu.one, context);
-            publish_gauge!("cpu.five", cpu.five, context);
-            publish_gauge!("cpu.fifteen", cpu.fifteen, context);
         };
         Ok(())
     }

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -98,10 +98,7 @@ describe('Enclave is runnning', () => {
             let keys = Object.keys(stats);
             expect(keys).to.include('memory.total;cage_uuid=cage_123;app_uuid=app_12345678');
             expect(keys).to.include('memory.avail;cage_uuid=cage_123;app_uuid=app_12345678');
-            expect(keys).to.include('memory.free;cage_uuid=cage_123;app_uuid=app_12345678');
             expect(keys).to.include('cpu.one;cage_uuid=cage_123;app_uuid=app_12345678');
-            expect(keys).to.include('cpu.five;cage_uuid=cage_123;app_uuid=app_12345678');
-            expect(keys).to.include('cpu.fifteen;cage_uuid=cage_123;app_uuid=app_12345678');
             expect(keys).to.include('cpu.cores;cage_uuid=cage_123;app_uuid=app_12345678');
             client.destroy();
         });


### PR DESCRIPTION
# Why
Some metrics aren't used need to stop logging them

# How
Remove unused metrics
