### PR TITLE
Bump openssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,9 +1302,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.46"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1343,11 +1343,10 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Evervault <engineering@evervault.com>"]
 [dependencies]
 hyper = { version = "0.14.4", features = ["server","http1","http2","tcp","stream","client"] }
 tokio = { version = "1.24.2", features = ["net", "macros", "rt", "rt-multi-thread", "io-util", "time"] }
-openssl = { version = "0.10.46", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 chrono =  { version = "0.4.22", default-features = false }
 aws-nitro-enclaves-nsm-api = "0.2.1"
 aws-nitro-enclaves-cose = "0.5.0"


### PR DESCRIPTION
# Why
Vulns flagged in Openssl dependency 

# How
Bump openssl dependency (no updates in changelog will impact cages)
