### PR TITLE
Improve API within Cages for the Nitro Security Module

### DIFF
--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -45,6 +45,6 @@ tokio-test = "0.4.2"
 [features]
 default = ["tls_termination"]
 tls_termination = ["dep:nom"]
-network_egress = ["dep:dns-message-parser", "dep:dashmap"]
+network_egress = ["dep:dns-message-parser", "dep:dashmap", "shared/network_egress"]
 enclave = ["dep:tokio-vsock", "shared/enclave"]
 not_enclave = []

--- a/data-plane/src/crypto/rand.rs
+++ b/data-plane/src/crypto/rand.rs
@@ -2,11 +2,10 @@ use crate::error::{Error, Result};
 
 #[cfg(feature = "enclave")]
 pub fn rand_bytes(buffer: &mut [u8]) -> Result<()> {
+    use crate::utils::nsm::NsmConnection;
     use aws_nitro_enclaves_nsm_api as nitro;
-    match nitro::driver::nsm_process_request(
-        nitro::driver::nsm_init(),
-        nitro::api::Request::GetRandom,
-    ) {
+    let nsm_conn = NsmConnection::try_new()?;
+    match nitro::driver::nsm_process_request(nsm_conn.fd(), nitro::api::Request::GetRandom) {
         nitro::api::Response::GetRandom { random } => {
             buffer.copy_from_slice(&random);
             Ok(())

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -82,8 +82,7 @@ impl EgressProxy {
 #[cfg(test)]
 mod tests {
     use crate::dns::egressproxy::EgressDomains;
-    use crate::dns::egressproxy::EgressProxy;
-    use crate::dns::error::DNSError::EgressDomainNotAllowed;
+    use shared::server::egress::{check_allow_list, EgressError::EgressDomainNotAllowed};
 
     #[test]
     fn test_valid_all_domains() {
@@ -93,7 +92,7 @@ mod tests {
             allow_all: true,
         };
         assert_eq!(
-            EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
             ()
         );
     }
@@ -105,7 +104,7 @@ mod tests {
             allow_all: false,
         };
         assert_eq!(
-            EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
             ()
         );
     }
@@ -117,7 +116,7 @@ mod tests {
             allow_all: false,
         };
         assert_eq!(
-            EgressProxy::check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
             ()
         );
     }
@@ -128,7 +127,7 @@ mod tests {
             wildcard: vec!["evervault.com".to_string()],
             allow_all: false,
         };
-        let result = EgressProxy::check_allow_list("google.com".to_string(), egress_domains);
+        let result = check_allow_list("google.com".to_string(), egress_domains);
         assert!(matches!(result, Err(EgressDomainNotAllowed(_))));
     }
 }

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -54,6 +54,9 @@ pub enum Error {
     EnvError(#[from] EnvError),
     #[error("Couldn't get cage context")]
     CageContextError(#[from] CageContextError),
+    #[cfg(feature = "enclave")]
+    #[error("Failed to get connection to nsm")]
+    NsmConnectionError(#[from] crate::utils::nsm::NsmConnectionError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/utils/mod.rs
+++ b/data-plane/src/utils/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "enclave")]
+pub mod nsm;
 #[cfg(feature = "tls_termination")]
 pub mod trx_handler;

--- a/data-plane/src/utils/nsm.rs
+++ b/data-plane/src/utils/nsm.rs
@@ -1,0 +1,31 @@
+use aws_nitro_enclaves_nsm_api as nitro;
+use thiserror::Error;
+
+/// Thin wrapper on the NSM API which handles initialization and cleanup.
+pub struct NsmConnection(i32);
+
+#[derive(Debug, Error)]
+pub enum NsmConnectionError {
+    #[error("Failed to initialize NSM connection")]
+    InitFailed,
+}
+
+impl NsmConnection {
+    pub fn try_new() -> Result<Self, NsmConnectionError> {
+        let nsm_fd = nitro::driver::nsm_init()();
+        if nsm_fd < 0 {
+            return Err(NsmConnectionError::InitFailed);
+        }
+        Ok(Self(nsm_fd))
+    }
+
+    pub fn fd(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::ops::Drop for NsmConnection {
+    fn drop(&mut self) {
+        nitro::driver::nsm_exit(self.fd());
+    }
+}

--- a/data-plane/src/utils/nsm.rs
+++ b/data-plane/src/utils/nsm.rs
@@ -12,7 +12,7 @@ pub enum NsmConnectionError {
 
 impl NsmConnection {
     pub fn try_new() -> Result<Self, NsmConnectionError> {
-        let nsm_fd = nitro::driver::nsm_init()();
+        let nsm_fd = nitro::driver::nsm_init();
         if nsm_fd < 0 {
             return Err(NsmConnectionError::InitFailed);
         }


### PR DESCRIPTION
# Why
The nitro security module exposes raw file descriptors via its driver api. The RawFD is not tidied up currently (using the nsm_exit function).

# How
This PR adds an NsmConnection type which handles the creation of a connection to the NSM device, and has a custom drop implementation to tidy up. It is effectively acting as a small `OwnedFd` impl for NSM.
