### PR TITLE
Support proxy protocol when TLS termination is disabled

### DIFF
--- a/data-plane/src/configuration.rs
+++ b/data-plane/src/configuration.rs
@@ -28,3 +28,7 @@ pub fn get_egress_ports() -> Vec<u16> {
         })
         .collect()
 }
+
+pub fn should_forward_proxy_protocol() -> bool {
+    std::env::var("FORWARD_PROXY_PROTOCOL").is_ok()
+}


### PR DESCRIPTION
# Why
Need to conditionally support proxy protocol passthrough when TLS Termination is disabled

# How
Check if `FORWARD_PROXY_PROTOCOL` is set, and if it is forward the header on the connection