### PR TITLE
[SPE-614] Log cages-e3 IP

### DIFF
--- a/control-plane/src/e3proxy.rs
+++ b/control-plane/src/e3proxy.rs
@@ -68,19 +68,19 @@ impl E3Proxy {
                     continue;
                 }
             }; // TODO: cache
-            println!("IP for E3 obtained");
+            println!("IP for E3 obtained: {e3_ip}");
             tokio::spawn(async move {
                 let e3_stream = match tokio::net::TcpStream::connect(e3_ip).await {
                     Ok(e3_stream) => e3_stream,
                     Err(e) => {
-                        eprintln!("Failed to connect to E3 — {e:?}");
+                        eprintln!("Failed to connect to E3 ({e3_ip}) — {e:?}");
                         Self::shutdown_conn(connection).await;
                         return;
                     }
                 };
 
                 if let Err(e) = shared::utils::pipe_streams(connection, e3_stream).await {
-                    eprintln!("Error streaming from Data Plane to e3 — {e:?}");
+                    eprintln!("Error streaming from Data Plane to e3 ({e3_ip})— {e:?}");
                 }
             });
         }


### PR DESCRIPTION
# Why
Need to debug when a specific cages-e3 instance is failing.

# How
Log e3 ip. It's an internal IP that's only available from within the VPC so can't be hit publicly.
