### PR TITLE
[SPE-616] Check if enclave is running before attempting to kill it

### DIFF
--- a/scripts/start-cage.sh
+++ b/scripts/start-cage.sh
@@ -5,7 +5,6 @@ export EC2_INSTANCE_ID=${INSTANCE_ID}
 
 describe_res=$(nitro-cli describe-enclaves)
 
-# Convert the string into a bash array of objects
 enclaves=($(echo "$describe_res" | jq -c '.[]'))
 
 if [[ ${#enclaves[@]} -gt 0 ]]; then

--- a/scripts/start-cage.sh
+++ b/scripts/start-cage.sh
@@ -3,14 +3,23 @@ INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identi
 
 export EC2_INSTANCE_ID=${INSTANCE_ID}
 
-# Kill all existing enclaves on this host
-echo "[HOST] Deployment started. Terminating old enclave..."
-nitro-cli terminate-enclave --all
-echo "[HOST] Enclave terminated. Waiting 10s..."
-sleep 10
+describe_res=$(nitro-cli describe-enclaves)
+
+# Convert the string into a bash array of objects
+enclaves=($(echo "$describe_res" | jq -c '.[]'))
+
+if [[ ${#enclaves[@]} -gt 0 ]]; then
+  echo "[HOST] There is an enclave already running on this host. Terminating it..."
+  nitro-cli terminate-enclave --all
+  echo " Enclave terminated. Waiting 10s..."
+  sleep 10
+else
+  echo "[HOST] No enclaves currently running on this host."
+fi
+
 
 # Provision new enclave using customer config
-echo "[HOST] Starting enclave..."
+echo "[HOST] Starting new enclave..."
 
 enclave_run_command="nitro-cli run-enclave --cpu-count $ENCLAVE_NUM_CPUS --memory $ENCLAVE_RAM_SIZE_MIB --enclave-cid 2021 --eif-path enclave.eif"
 
@@ -22,8 +31,8 @@ else
   eval "$enclave_run_command"
 fi
 
-echo "[HOST] Enclave started... Waiting 10 seconds for warmup."
-sleep 10
+echo "[HOST] Enclave started... Waiting 5 seconds for warmup."
+sleep 5
 
 if [ "$ENCLAVE_DEBUG_MODE" = "true" ] ; then
   # Create stdout streams for any running enclaves

--- a/scripts/start-cage.sh
+++ b/scripts/start-cage.sh
@@ -10,7 +10,7 @@ enclaves=($(echo "$describe_res" | jq -c '.[]'))
 if [[ ${#enclaves[@]} -gt 0 ]]; then
   echo "[HOST] There is an enclave already running on this host. Terminating it..."
   nitro-cli terminate-enclave --all
-  echo " Enclave terminated. Waiting 10s..."
+  echo "[HOST] Enclave terminated. Waiting 10s..."
   sleep 10
 else
   echo "[HOST] No enclaves currently running on this host."


### PR DESCRIPTION
# Why
First part of improvement to deployment. Should only try to kill the existing enclave if it's running. Another PR will start killing the enclave when a sigterm is retrieved. This will speed up the time it takes a cage to start.

# How
Use the nitro-cli to describe-enclaves and check if there's an enclave running. If there is, kill it and sleep. If not continue.
