### PR TITLE
Return decryption failure error to client

### DIFF
--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -276,7 +276,7 @@ pub async fn handle_standard_request(
             Ok(decrypted) => decrypted,
             Err(e) => {
                 eprintln!("Failed to decrypt — {e}");
-                return build_error_response(Some(String::from("Failed to decrypt ciphertexts")));
+                return build_error_response(Some(format!("Failed to decrypt ciphertexts {e}")));
             }
         };
 


### PR DESCRIPTION
# Why
Return ClientError to client when decryption request to E3 fails. It will reveal if the issue was with deserialisation/network/bad request when two enclaves are talking to each other and otherwise have no logging

# How
Return the error in the response
