### PR TITLE
Migrate control plane to amazon linux 2023

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2023
 RUN yum -y update
-RUN yum install -y aws-nitro-enclaves-cli wget
+RUN yum install -y aws-nitro-enclaves-cli
 
 COPY ./control-plane .
 RUN chmod a+x ./control-plane

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -1,10 +1,6 @@
-FROM amazonlinux:2
-
-#Patch vuln https://alas.aws.amazon.com/AL2/ALAS-2022-1776.html
-RUN yum update golang
-
-RUN amazon-linux-extras install -y aws-nitro-enclaves-cli
-RUN yum -y update ; yum install wget -y
+FROM amazonlinux:2023
+RUN yum -y update
+RUN yum install -y aws-nitro-enclaves-cli wget
 
 COPY ./control-plane .
 RUN chmod a+x ./control-plane

--- a/scripts/start-cage.sh
+++ b/scripts/start-cage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r ."instanceId")
+INSTANCE_ID=$(curl http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r ."instanceId")
 
 export EC2_INSTANCE_ID=${INSTANCE_ID}
 


### PR DESCRIPTION
# Why
Migrate Control plane to amazon linux 2023 for long term support

# How
Update base image, replace amazon-linux-extras with yum. Remove use of wget with curl.