### PR TITLE
Always perform data plane health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV DATA_PLANE_SERVICE_PATH=/etc/service/data-plane
 ENV CONTROL_PLANE_EXECUTABLE_PATH=/control-plane
 ENV CONTROL_PLANE_SERVICE_PATH=/etc/service/control-plane
 ENV START_EV_SERVICES_PATH=/etc/service/ev-services-entrypoint
-ENV DATA_PLANE_HEALTH_CHECKS=true
 ENV EV_API_KEY_AUTH=true
 ENV EV_EGRESS_ALLOW_LIST=jsonplaceholder.typicode.com
 

--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -4,18 +4,13 @@ use hyper::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
 use shared::server::health::{HealthCheckLog, HealthCheckStatus};
 use shared::server::{error::ServerResult, tcp::TcpServer, Listener};
-use shared::{env_var_present_and_true, ENCLAVE_HEALTH_CHECK_PORT};
+use shared::ENCLAVE_HEALTH_CHECK_PORT;
 use std::net::SocketAddr;
 
 pub const CONTROL_PLANE_HEALTH_CHECK_PORT: u16 = 3032;
-#[derive(Clone)]
-pub struct HealthCheckServerConfig {
-    data_plane_checks_enabled: bool,
-}
 
 pub struct HealthCheckServer {
     tcp_server: TcpServer,
-    config: HealthCheckServerConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -25,20 +20,13 @@ struct CombinedHealthCheckLog {
     data_plane: HealthCheckLog,
 }
 
-async fn run_ecs_health_check_service(
-    config: HealthCheckServerConfig,
-) -> std::result::Result<Response<Body>, ServerError> {
+async fn run_ecs_health_check_service() -> std::result::Result<Response<Body>, ServerError> {
     let control_plane = HealthCheckLog::new(
         HealthCheckStatus::Ok,
         Some("Control plane is running".into()),
     );
 
-    let data_plane = if config.data_plane_checks_enabled {
-        health_check_data_plane().await
-    } else {
-        HealthCheckLog::new(HealthCheckStatus::Ignored, None)
-    };
-
+    let data_plane = health_check_data_plane().await;
     let status_to_return = [control_plane.status.clone(), data_plane.status.clone()]
         .iter()
         .max()
@@ -88,42 +76,32 @@ async fn health_check_data_plane() -> HealthCheckLog {
 
 impl HealthCheckServer {
     pub async fn new() -> ServerResult<Self> {
-        let data_plane_checks_enabled = env_var_present_and_true!("DATA_PLANE_HEALTH_CHECKS");
         let tcp_server = TcpServer::bind(SocketAddr::from((
             [0, 0, 0, 0],
             CONTROL_PLANE_HEALTH_CHECK_PORT,
         )))
         .await?;
-        Ok(HealthCheckServer {
-            tcp_server,
-            config: HealthCheckServerConfig {
-                data_plane_checks_enabled,
-            },
-        })
+        Ok(HealthCheckServer { tcp_server })
     }
 
     pub async fn start(&mut self) -> ServerResult<()> {
         println!(
-            "Control plane health-check server running on port {CONTROL_PLANE_HEALTH_CHECK_PORT}. Also checking data-plane: {}", self.config.data_plane_checks_enabled
+            "Control plane health-check server running on port {CONTROL_PLANE_HEALTH_CHECK_PORT}"
         );
 
         loop {
             let stream = self.tcp_server.accept().await?;
-            let config = self.config.clone();
-            let service = hyper::service::service_fn(move |request: Request<Body>| {
-                let config = config.clone();
-                async move {
-                    match request
-                        .headers()
-                        .get("User-Agent")
-                        .map(|value| value.as_bytes())
-                    {
-                        Some(b"ECS-HealthCheck") => run_ecs_health_check_service(config).await,
-                        _ => Response::builder()
-                            .status(500)
-                            .body(Body::from("Unsupported health check type!"))
-                            .map_err(ServerError::from),
-                    }
+            let service = hyper::service::service_fn(move |request: Request<Body>| async move {
+                match request
+                    .headers()
+                    .get("User-Agent")
+                    .map(|value| value.as_bytes())
+                {
+                    Some(b"ECS-HealthCheck") => run_ecs_health_check_service().await,
+                    _ => Response::builder()
+                        .status(500)
+                        .body(Body::from("Unsupported health check type!"))
+                        .map_err(ServerError::from),
                 }
             });
             if let Err(error) = hyper::server::conn::Http::new()
@@ -148,12 +126,9 @@ mod health_check_tests {
     }
 
     #[tokio::test]
-    async fn test_cage_health_check_service_deep() {
+    async fn test_cage_health_check_service() {
         // the data-plane status should error, as its not running
-        let config = HealthCheckServerConfig {
-            data_plane_checks_enabled: true,
-        };
-        let response = run_ecs_health_check_service(config).await.unwrap();
+        let response = run_ecs_health_check_service().await.unwrap();
         assert_eq!(response.status(), 500);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
@@ -161,34 +136,6 @@ mod health_check_tests {
             health_check_log.data_plane.status,
             HealthCheckStatus::Err
         ));
-    }
-
-    #[tokio::test]
-    async fn test_cage_health_check_service_shallow() {
-        // the health check should succeed, as the data-plane isn't checked
-        let config = HealthCheckServerConfig {
-            data_plane_checks_enabled: false,
-        };
-        let response = run_ecs_health_check_service(config).await.unwrap();
-        assert_eq!(response.status(), 200);
-        println!("shallow response: {response:?}");
-        let health_check_log = response_to_health_check_log(response).await;
-        assert!(matches!(
-            health_check_log.data_plane.status,
-            HealthCheckStatus::Ignored
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_consecutive_ecs_health_check_service_calls() {
-        // state should not change, so the health checks should keep passing
-        let config = HealthCheckServerConfig {
-            data_plane_checks_enabled: false,
-        };
-        let response = run_ecs_health_check_service(config.clone()).await.unwrap();
-        assert_eq!(response.status(), 200);
-        let response = run_ecs_health_check_service(config).await.unwrap();
-        assert_eq!(response.status(), 200);
     }
 
     #[tokio::test]

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -16,7 +16,7 @@ use futures::future::join_all;
 use data_plane::env::Environment;
 use data_plane::health::start_health_check_server;
 use data_plane::stats_client::StatsClient;
-use shared::{env_var_present_and_true, ENCLAVE_CONNECT_PORT};
+use shared::ENCLAVE_CONNECT_PORT;
 
 #[tokio::main]
 async fn main() {
@@ -30,11 +30,7 @@ async fn main() {
         .and_then(|port_str| port_str.as_str().parse::<u16>().ok())
         .unwrap_or(8008);
 
-    if env_var_present_and_true!("DATA_PLANE_HEALTH_CHECKS") {
-        tokio::join!(start(data_plane_port), start_health_check_server(),);
-    } else {
-        start(data_plane_port).await;
-    }
+    tokio::join!(start(data_plane_port), start_health_check_server());
 }
 
 #[cfg(not(feature = "network_egress"))]

--- a/e2e-tests/run-all-feature-tests.sh
+++ b/e2e-tests/run-all-feature-tests.sh
@@ -60,12 +60,6 @@ echo "data-plane health checks ON, control-plane ON, data-plane OFF"
 docker compose exec cages sh -c "sv down data-plane"
 npm run health-check-tests "should fail"
 
-echo "data-plane health checks OFF, control-plane ON, data-plane OFF"
-docker compose down
-EV_DATA_PLANE_HEALTH_CHECKS=false docker compose up -d 
-docker compose exec cages sh -c "sv down data-plane"
-npm run health-check-tests "should succeed"
-
 echo "API Key Auth Tests"
 docker compose down
 EV_API_KEY_AUTH=true docker compose up -d

--- a/shared/src/utils.rs
+++ b/shared/src/utils.rs
@@ -46,7 +46,7 @@ macro_rules! print_version {
 #[macro_export]
 macro_rules! env_var_present_and_true {
     ($var_name:tt) => {
-        match std::env::var("DATA_PLANE_HEALTH_CHECKS") {
+        match std::env::var($var_name) {
             Ok(s) if s.as_str() == "true" => true,
             _ => false,
         }


### PR DESCRIPTION
# Why
Always perform data plane health checks instead of relying on env var

# How
Now that cages is open source it clear and attestable to see what checks are being performed
