### PR TITLE
Read dataplane config from file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ ENV DATA_PLANE_SERVICE_PATH=/etc/service/data-plane
 ENV CONTROL_PLANE_EXECUTABLE_PATH=/control-plane
 ENV CONTROL_PLANE_SERVICE_PATH=/etc/service/control-plane
 ENV START_EV_SERVICES_PATH=/etc/service/ev-services-entrypoint
-ENV EV_API_KEY_AUTH=true
-ENV EV_EGRESS_ALLOW_LIST=jsonplaceholder.typicode.com
 
 EXPOSE 443
 

--- a/control-plane/src/egressproxy.rs
+++ b/control-plane/src/egressproxy.rs
@@ -25,7 +25,7 @@ impl EgressProxy {
     pub async fn listen() -> Result<()> {
         println!("Egress proxy started");
         let mut server = get_vsock_server(EGRESS_PROXY_VSOCK_PORT, Parent).await?;
-        let allowed_domains = shared::server::egress::get_egress_allow_list();
+        let allowed_domains = shared::server::egress::get_egress_allow_list_from_env();
 
         loop {
             let domains = allowed_domains.clone();

--- a/data-plane/src/configuration.rs
+++ b/data-plane/src/configuration.rs
@@ -18,17 +18,6 @@ pub fn get_e3_host() -> String {
     "localhost".to_string()
 }
 
-pub fn get_egress_ports() -> Vec<u16> {
-    let port_str = std::env::var("EGRESS_PORTS").unwrap_or("443".to_string());
-    port_str
-        .split(',')
-        .map(|port| {
-            port.parse::<u16>()
-                .unwrap_or_else(|_| panic!("Could not parse egress port as u16: {port}"))
-        })
-        .collect()
-}
-
 pub fn should_forward_proxy_protocol() -> bool {
     std::env::var("FORWARD_PROXY_PROTOCOL").is_ok()
 }

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -1,6 +1,7 @@
 use super::error::DNSError;
 use crate::dns::cache::Cache;
 use crate::dns::error::DNSError::MissingIP;
+use crate::FEATURE_CONTEXT;
 use shared::rpc::request::ExternalRequest;
 use shared::server::egress::check_allow_list;
 use shared::server::egress::get_hostname;
@@ -20,9 +21,9 @@ use rand::seq::SliceRandom;
 pub struct EgressProxy;
 
 impl EgressProxy {
-    pub async fn listen(port: u16, allowed_domains: EgressDomains) -> ServerResult<()> {
+    pub async fn listen(port: u16) -> ServerResult<()> {
         println!("Egress proxy started on port {port}");
-
+        let allowed_domains = &FEATURE_CONTEXT.get().unwrap().egress.allow_list;
         let mut server =
             TcpServer::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port)).await?;
 

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -1,7 +1,7 @@
 use super::error::DNSError;
 use crate::dns::cache::Cache;
 use crate::dns::error::DNSError::MissingIP;
-use crate::FEATURE_CONTEXT;
+use crate::FeatureContext;
 use shared::rpc::request::ExternalRequest;
 use shared::server::egress::check_allow_list;
 use shared::server::egress::get_hostname;
@@ -23,7 +23,7 @@ pub struct EgressProxy;
 impl EgressProxy {
     pub async fn listen(port: u16) -> ServerResult<()> {
         println!("Egress proxy started on port {port}");
-        let allowed_domains = &FEATURE_CONTEXT.get().unwrap().egress.allow_list;
+        let allowed_domains = FeatureContext::get().egress.allow_list;
         let mut server =
             TcpServer::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port)).await?;
 
@@ -46,7 +46,6 @@ impl EgressProxy {
         allowed_domains: EgressDomains,
     ) -> Result<(), DNSError> {
         let mut buf = vec![0u8; 4096];
-
         let n = external_stream.read(&mut buf).await?;
         let customer_data = &mut buf[..n];
 

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -4,8 +4,6 @@ use std::{fs::File, io::Write};
 use crate::cert_provisioner_client::CertProvisionerClient;
 #[cfg(not(feature = "tls_termination"))]
 use crate::config_client::ConfigClient;
-#[cfg(not(feature = "tls_termination"))]
-use crate::CageContext;
 use crate::{base_tls_client::ClientError, CageContextError};
 use hyper::header::InvalidHeaderValue;
 use serde_json::json;

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -81,6 +81,8 @@ impl Environment {
 
     #[cfg(not(feature = "tls_termination"))]
     pub async fn init_without_certs(self) -> Result<(), EnvError> {
+        use crate::CageContext;
+
         println!("Initializing env without TLS termination, sending request to control plane for cert provisioner token.");
         let token = self.config_client.get_cert_token().await.unwrap().token();
         let cert_response = self.cert_provisioner_client.get_secrets(token).await?;

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -117,7 +117,7 @@ impl FeatureContext {
                 let dataplane_context = FeatureContext {
                     api_key_auth,
                     trx_logging_enabled,
-                    egress: None,
+                    egress: EgressContext::get(),
                 };
                 FEATURE_CONTEXT.get_or_init(|| dataplane_context)
             }
@@ -136,8 +136,21 @@ pub struct FeatureContext {
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct EgressContext {
-    ports: String,
+    ports: Vec<u16>,
     allow_list: bool,
+}
+
+impl EgressContext {
+    #[cfg(feature = "network_egress")]
+    pub fn get() -> Option<EgressContext> {
+        let ports = get_egress_ports();
+        let allow_list = shared::server::egress::get_egress_allow_list();
+        ();
+        Some(EgressContext { ports, allow_list })
+    }
+    pub fn get() -> Option<EgressContext> {
+        None
+    }
 }
 
 fn read_dataplane_context() -> Option<FeatureContext> {

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -143,11 +143,11 @@ pub struct EgressContext {
 impl EgressContext {
     #[cfg(feature = "network_egress")]
     pub fn get() -> Option<EgressContext> {
-        let ports = get_egress_ports();
+        let ports = configuration::get_egress_ports();
         let allow_list = shared::server::egress::get_egress_allow_list();
-        ();
         Some(EgressContext { ports, allow_list })
     }
+    #[cfg(not(feature = "network_egress"))]
     pub fn get() -> Option<EgressContext> {
         None
     }

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -55,7 +55,7 @@ impl CageContext {
         CAGE_CONTEXT.get_or_init(|| ctx);
     }
 
-    pub fn new(app_uuid: String, team_uuid: String, cage_uuid: String, cage_name: String) -> Self {
+    pub fn new(team_uuid: String, app_uuid: String, cage_uuid: String, cage_name: String) -> Self {
         Self {
             cage_uuid,
             app_uuid,

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -62,7 +62,7 @@ async fn start(data_plane_port: u16) {
     StatsClient::init();
     FeatureContext::set();
     let ports = FeatureContext::get().egress.ports;
-    let egress_proxies = join_all(ports.into_iter().map(|port| EgressProxy::listen(port)));
+    let egress_proxies = join_all(ports.into_iter().map(EgressProxy::listen));
 
     let (_, dns_result, e3_api_result, egress_results, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -16,6 +16,7 @@ use futures::future::join_all;
 use data_plane::env::Environment;
 use data_plane::health::start_health_check_server;
 use data_plane::stats_client::StatsClient;
+use data_plane::FeatureContext;
 use shared::ENCLAVE_CONNECT_PORT;
 
 #[tokio::main]
@@ -38,6 +39,7 @@ async fn start(data_plane_port: u16) {
     use data_plane::{crypto::api::CryptoApi, stats::StatsProxy};
 
     StatsClient::init();
+    FeatureContext::set();
     println!("Running data plane with egress disabled");
     let (_, e3_api_result, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),
@@ -59,6 +61,7 @@ async fn start(data_plane_port: u16) {
     use data_plane::{crypto::api::CryptoApi, stats::StatsProxy};
 
     StatsClient::init();
+    FeatureContext::set();
     let ports = configuration::get_egress_ports();
     let allowed_domains = shared::server::egress::get_egress_allow_list();
     let egress_proxies = join_all(

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -3,20 +3,19 @@ use shared::server::Listener;
 use shared::server::CID::Enclave;
 use shared::{print_version, server::get_vsock_server_with_proxy_protocol};
 
-#[cfg(any(feature = "network_egress", not(feature = "tls_termination")))]
+#[cfg(not(feature = "tls_termination"))]
 use data_plane::configuration;
 #[cfg(feature = "network_egress")]
 use data_plane::dns::egressproxy::EgressProxy;
 #[cfg(feature = "network_egress")]
 use data_plane::dns::enclavedns::EnclaveDns;
-#[cfg(feature = "network_egress")]
-use futures::future::join_all;
-
 #[cfg(not(feature = "tls_termination"))]
 use data_plane::env::Environment;
 use data_plane::health::start_health_check_server;
 use data_plane::stats_client::StatsClient;
 use data_plane::FeatureContext;
+#[cfg(feature = "network_egress")]
+use futures::future::join_all;
 use shared::ENCLAVE_CONNECT_PORT;
 
 #[tokio::main]
@@ -62,12 +61,8 @@ async fn start(data_plane_port: u16) {
 
     StatsClient::init();
     FeatureContext::set();
-    let allowed_domains = shared::server::egress::get_egress_allow_list();
-    let egress_proxies = join_all(
-        ports
-            .into_iter()
-            .map(|port| EgressProxy::listen(port, allowed_domains.clone())),
-    );
+    let ports = FeatureContext::get().egress.ports;
+    let egress_proxies = join_all(ports.into_iter().map(|port| EgressProxy::listen(port)));
 
     let (_, dns_result, e3_api_result, egress_results, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -62,7 +62,6 @@ async fn start(data_plane_port: u16) {
 
     StatsClient::init();
     FeatureContext::set();
-    let ports = configuration::get_egress_ports();
     let allowed_domains = shared::server::egress::get_egress_allow_list();
     let egress_proxies = join_all(
         ports

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -6,7 +6,7 @@ use crate::base_tls_client::ClientError;
 use crate::e3client::DecryptRequest;
 use crate::e3client::{self, AuthRequest, E3Client};
 use crate::error::{AuthError, Result};
-use crate::{CageContext, CAGE_CONTEXT};
+use crate::{CageContext, CAGE_CONTEXT, FEATURE_CONTEXT, FeatureContext};
 
 use crate::utils::trx_handler::{start_log_handler, LogHandlerMessage};
 
@@ -45,7 +45,8 @@ where
     ) = unbounded_channel();
 
     let cage_context = CAGE_CONTEXT.get().expect("Couldn't get cage context");
-    if cage_context.trx_logging_enabled {
+    let feature_context = FEATURE_CONTEXT.get().expect("Couldn't get cage context");
+    if feature_context.trx_logging_enabled {
         let tx_for_handler = tx.clone();
         tokio::spawn(async move {
             start_log_handler(tx_for_handler, rx).await;
@@ -65,10 +66,12 @@ where
         let server = http_server.clone();
         let e3_client_for_connection = e3_client.clone();
         let cage_context_for_connection = cage_context.clone();
+        let feature_context_for_connection = feature_context.clone();
         let tx_for_connection = tx.clone();
         tokio::spawn(async move {
             let e3_client_for_tcp = e3_client_for_connection.clone();
             let cage_context_for_tcp = cage_context_for_connection.clone();
+            let feature_context_for_tcp = feature_context_for_connection.clone();
             let tx_for_tcp = tx_for_connection.clone();
             let remote_ip = stream.get_remote_addr();
             let sent_response = server
@@ -77,6 +80,7 @@ where
                     service_fn(|mut req: Request<Body>| {
                         let e3_client_for_req = e3_client_for_tcp.clone();
                         let cage_context_for_req = cage_context_for_tcp.clone();
+                        let feature_context_for_req = feature_context_for_tcp.clone();
                         let tx_for_req = tx_for_tcp.clone();
                         let remote_ip = remote_ip.clone();
                         async move {
@@ -87,7 +91,7 @@ where
                               add_remote_ip_to_forwarded_for_header(&mut req, remote_ip.as_deref().unwrap());
                             }
 
-                            let trx_logging_enabled = cage_context_for_req.trx_logging_enabled;
+                            let trx_logging_enabled = feature_context_for_req.trx_logging_enabled;
 
                             if  trx_logging_enabled {
                                 add_ev_ctx_header_to_request(&mut req, &trx_id);
@@ -98,6 +102,7 @@ where
                                 port,
                                 e3_client_for_req,
                                 cage_context_for_req,
+                                feature_context_for_req,
                                 &mut trx_context,
                             )
                             .await;
@@ -141,13 +146,14 @@ async fn handle_incoming_request(
     customer_port: u16,
     e3_client: Arc<E3Client>,
     cage_context: CageContext,
+    feature_context: FeatureContext,
     trx_context: &mut TrxContextBuilder,
 ) -> Response<Body> {
     // Extract API Key header and authenticate request
     // Run parser over payload
     // Serialize request onto socket
 
-    if cage_context.api_key_auth {
+    if feature_context.api_key_auth {
         println!("Authenticating request");
         let api_key = match req
             .headers()

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -6,7 +6,7 @@ use crate::base_tls_client::ClientError;
 use crate::e3client::DecryptRequest;
 use crate::e3client::{self, AuthRequest, E3Client};
 use crate::error::{AuthError, Result};
-use crate::{CageContext, CAGE_CONTEXT, FEATURE_CONTEXT, FeatureContext};
+use crate::{CageContext, FeatureContext, CAGE_CONTEXT, FEATURE_CONTEXT};
 
 use crate::utils::trx_handler::{start_log_handler, LogHandlerMessage};
 

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -75,11 +75,11 @@ where
                     service_fn(|mut req: Request<Body>| {
                         let e3_client_for_req = e3_client_for_tcp.clone();
                         let feature_context = FEATURE_CONTEXT.get().expect("Couldn't get cage context");
-                        let cage_context_for_req = CAGE_CONTEXT.get().expect("Couldn't get cage context");
+                        let cage_context = CAGE_CONTEXT.get().expect("Couldn't get cage context");
                         let tx_for_req = tx_for_tcp.clone();
                         let remote_ip = remote_ip.clone();
                         async move {
-                            let (mut trx_context, request_timer) = init_trx(&cage_context_for_req, &req);
+                            let (mut trx_context, request_timer) = init_trx(cage_context, &req);
                             let trx_id = trx_context.get_trx_id();
                             if remote_ip.is_some() {
                               trx_context.remote_ip(remote_ip.clone());
@@ -96,7 +96,7 @@ where
                                 req,
                                 port,
                                 e3_client_for_req,
-                                cage_context_for_req.clone(),
+                                cage_context.clone(),
                                 feature_context.clone(),
                                 &mut trx_context,
                             )

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -74,7 +74,7 @@ where
                     stream,
                     service_fn(|mut req: Request<Body>| {
                         let e3_client_for_req = e3_client_for_tcp.clone();
-                        let feature_context = FEATURE_CONTEXT.get().expect("Couldn't get cage context");
+                        let feature_context = FeatureContext::get();
                         let cage_context = CAGE_CONTEXT.get().expect("Couldn't get cage context");
                         let tx_for_req = tx_for_tcp.clone();
                         let remote_ip = remote_ip.clone();

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -334,16 +334,7 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "my-sick-cage".to_string();
-        let api_key_auth = true;
-        let trx_logging = true;
-        let ctx = CageContext::new(
-            app_uuid,
-            team_uuid,
-            cage_uuid,
-            cage_name,
-            api_key_auth,
-            trx_logging,
-        );
+        let ctx = CageContext::new(app_uuid, team_uuid, cage_uuid, cage_name);
         let server_name = Some(ctx.get_cert_name());
         CageContext::set(ctx);
         let (cert, key) = generate_ca().unwrap();
@@ -375,16 +366,7 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "my-sick-cage".to_string();
-        let api_key_auth = false;
-        let trx_logging = true;
-        let ctx = CageContext::new(
-            app_uuid,
-            team_uuid,
-            cage_uuid,
-            cage_name,
-            api_key_auth,
-            trx_logging,
-        );
+        let ctx = CageContext::new(app_uuid, team_uuid, cage_uuid, cage_name);
         CageContext::set(ctx.clone());
         let server_name = Some(ctx.get_cert_name());
         let (cert, key) = generate_ca().unwrap();
@@ -421,8 +403,6 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "a-cage".to_string();
-        let api_key_auth = true;
-        let trx_logging = true;
         let ctx = CageContext::new(
             app_uuid,
             team_uuid,
@@ -441,16 +421,7 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "a-sick-cage-that-has-a-very-long-name".to_string();
-        let api_key_auth = true;
-        let trx_logging = true;
-        let ctx = CageContext::new(
-            app_uuid,
-            team_uuid,
-            cage_uuid,
-            cage_name,
-            api_key_auth,
-            trx_logging,
-        );
+        let ctx = CageContext::new(app_uuid, team_uuid, cage_uuid, cage_name);
         let hostname = ctx.get_cert_name();
 
         if cfg!(staging) {
@@ -482,16 +453,7 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "my-sick-cage".to_string();
-        let api_key_auth = true;
-        let trx_logging = true;
-        let ctx = CageContext::new(
-            app_uuid,
-            team_uuid,
-            cage_uuid,
-            cage_name,
-            api_key_auth,
-            trx_logging,
-        );
+        let ctx = CageContext::new(app_uuid, team_uuid, cage_uuid, cage_name);
         let hostname = ctx.get_cert_name();
         if cfg!(staging) {
             assert!(hostname.ends_with(".dev"));

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -403,12 +403,7 @@ mod tests {
         let team_uuid = "team_456".to_string();
         let cage_uuid = "cage_123".to_string();
         let cage_name = "a-cage".to_string();
-        let ctx = CageContext::new(
-            app_uuid,
-            team_uuid,
-            cage_uuid,
-            cage_name
-        );
+        let ctx = CageContext::new(app_uuid, team_uuid, cage_uuid, cage_name);
         let hostname = ctx.get_cert_name();
         assert!(hostname.ends_with(".dev"));
     }

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -407,9 +407,7 @@ mod tests {
             app_uuid,
             team_uuid,
             cage_uuid,
-            cage_name,
-            api_key_auth,
-            trx_logging,
+            cage_name
         );
         let hostname = ctx.get_cert_name();
         assert!(hostname.ends_with(".dev"));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     networks:
       mynetwork:
         ipv4_address: 172.20.0.6  
+    platform: linux/amd64    
   cages:
     build: .
     dns: 127.0.0.1

--- a/e2e-tests/run-all-feature-tests.sh
+++ b/e2e-tests/run-all-feature-tests.sh
@@ -42,7 +42,7 @@ docker compose build
 
 echo "Running cage container"
 # run the container
-docker compose up -d
+EV_API_KEY_AUTH=true docker compose up -d
 echo "SLEEPING 15 SECONDS to let cage initialize..."
 sleep 15
 

--- a/e2e-tests/scripts/start-data-plane.sh
+++ b/e2e-tests/scripts/start-data-plane.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-export EV_APP_UUID=app_12345678
-export CAGE_UUID=cage_123456
-export EV_TEAM_UUID=team_12345678
-export EV_CAGE_NAME=test-cage
-
+echo {"apiKeyAuth":true,"egress":{"ports":"443", allowList:"*"},"trxLoggingEnabled":"true" > /etc/dataplane-config.json
 
 exec $DATA_PLANE_EXECUTABLE_PATH

--- a/e2e-tests/scripts/start-data-plane.sh
+++ b/e2e-tests/scripts/start-data-plane.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo {"apiKeyAuth":true,"egress":{"ports":"443", allowList:"*"},"trxLoggingEnabled":"true" > /etc/dataplane-config.json
+echo {\"apiKeyAuth\":\"true\",\"egress\":{},\"trxLoggingEnabled\":\"true\"} > /etc/dataplane-config.json
 
 exec $DATA_PLANE_EXECUTABLE_PATH

--- a/e2e-tests/scripts/start-data-plane.sh
+++ b/e2e-tests/scripts/start-data-plane.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo {\"apiKeyAuth\":\"true\",\"egress\":{},\"trxLoggingEnabled\":\"true\"} > /etc/dataplane-config.json
+echo {\"api_key_auth\":true,\"egress\":{\"ports\": \"443\", \"allow_list\": \"jsonplaceholder.typicode.com\"},\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 
 exec $DATA_PLANE_EXECUTABLE_PATH

--- a/e2e-tests/scripts/start-data-plane.sh
+++ b/e2e-tests/scripts/start-data-plane.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo {\"api_key_auth\":true,\"egress\":{\"ports\": \"443\", \"allow_list\": \"jsonplaceholder.typicode.com\"},\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+echo {\"api_key_auth\":${EV_API_KEY_AUTH},\"egress\":{\"ports\": \"443\", \"allow_list\": \"jsonplaceholder.typicode.com\"},\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 
 exec $DATA_PLANE_EXECUTABLE_PATH

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -3,6 +3,7 @@ use tls_parser::{
     nom::Finish, parse_tls_extensions, parse_tls_plaintext, TlsExtension, TlsMessage,
     TlsMessageHandshake,
 };
+use serde::Deserialize;
 
 #[derive(Debug, Error)]
 pub enum EgressError {
@@ -84,7 +85,7 @@ pub fn check_allow_list(
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Deserialize)]
 pub struct EgressDomains {
     pub wildcard: Vec<String>,
     pub exact: Vec<String>,

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -47,8 +47,12 @@ pub fn get_hostname(data: Vec<u8>) -> Result<String, EgressError> {
     Ok(destination)
 }
 
-pub fn get_egress_allow_list() -> EgressDomains {
+pub fn get_egress_allow_list_from_env() -> EgressDomains {
     let domain_str = std::env::var("EV_EGRESS_ALLOW_LIST").unwrap_or("".to_string());
+    get_egress_allow_list(domain_str)
+}
+
+pub fn get_egress_allow_list(domain_str: String) -> EgressDomains {
     let (wildcard, exact): (Vec<String>, Vec<String>) = domain_str
         .split(',')
         .map(|domain| domain.to_string())


### PR DESCRIPTION
# Why
Squashing the docker layers for repro builds causes ENV directives to be lost

# How
- Read config from file instead
- For backwards compatibility with the CLI revert to checking env if file is not present

