### PR TITLE
Add versioning headers to base tls clients

### DIFF
--- a/data-plane/src/base_tls_client/mod.rs
+++ b/data-plane/src/base_tls_client/mod.rs
@@ -10,6 +10,7 @@ use tokio_rustls::{client::TlsStream, TlsConnector};
 
 use crate::connection::{self, Connection};
 use crate::crypto::token::AttestationAuth;
+use shared::{CLIENT_MAJOR_VERSION, CLIENT_VERSION};
 
 #[derive(Clone)]
 pub struct BaseClient {
@@ -65,6 +66,14 @@ impl BaseClient {
         let mut request = hyper::Request::builder()
             .uri(uri)
             .header("Content-Type", "application/json")
+            .header(
+                "User-Agent",
+                format!("Cage-Data-Plane/{}", &*CLIENT_VERSION),
+            )
+            .header(
+                "Accept",
+                format!("application/json;version={}", &*CLIENT_MAJOR_VERSION),
+            )
             .method(method)
             .body(payload)
             .expect("Failed to create request");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,3 +19,8 @@ pub mod logging;
 pub mod rpc;
 pub mod server;
 pub mod utils;
+
+lazy_static::lazy_static! {
+  pub static ref CLIENT_VERSION: String = option_env!("CARGO_PKG_VERSION").map(|version| version.to_string()).unwrap_or_else(|| "unknown".to_string());
+  pub static ref CLIENT_MAJOR_VERSION: String = option_env!("CARGO_PKG_VERSION").and_then(|version| version.split(".").next().map(|major| major.to_string())).unwrap_or_else(|| "unknown".to_string());
+}


### PR DESCRIPTION
# Why
Need to include version info into the data plane to add long term support in peripheral services

# How
Update base tls client to include a versioned user agent and accept header
