### PR TITLE
Add logging on decryption failure

### DIFF
--- a/data-plane/src/e3client/mod.rs
+++ b/data-plane/src/e3client/mod.rs
@@ -91,7 +91,10 @@ impl E3Client {
             .take(retries);
 
         Retry::spawn(retry_strategy, || async {
-            self.decrypt(payload.clone()).await
+            self.decrypt(payload.clone()).await.map_err(|e| {
+                println!("Error attempting decryption {e:?}");
+                e
+            })
         })
         .await
     }


### PR DESCRIPTION
# Why
Add logging to surface retry failure in debug mode cages

# How
Print error on retry
