### PR TITLE
Add backwards compat for proxy protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "rustls-pemfile",
+ "semver",
  "serde",
  "serde_json",
  "shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "dns-message-parser",
  "hyper",
  "lazy_static",
+ "ppp",
  "rand",
  "rustls-pemfile",
  "semver",
@@ -603,6 +604,7 @@ dependencies = [
  "tls-parser",
  "tokio",
  "tokio-rustls",
+ "tokio-test",
  "tokio-vsock",
  "trust-dns-resolver",
 ]

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -25,6 +25,7 @@ rustls-pemfile = "1.0.1"
 aws-config = "0.55.0"
 aws-types = "0.55.0"
 aws-sdk-sns = "0.25.0"
+semver = "1.0.17"
 
 [features]
 default = []

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -27,6 +27,10 @@ aws-types = "0.55.0"
 aws-sdk-sns = "0.25.0"
 semver = "1.0.17"
 
+[dev-dependencies]
+tokio-test = "0.4.2"
+ppp = "2.2.0"
+
 [features]
 default = []
 network_egress = ["shared/network_egress"]

--- a/control-plane/src/configuration.rs
+++ b/control-plane/src/configuration.rs
@@ -103,3 +103,7 @@ pub fn get_cert_provisioner_mtls_key_env() -> Result<String, std::env::VarError>
 pub fn get_cert_provisioner_mtls_root_cert_env() -> Result<String, std::env::VarError> {
     std::env::var("CERT_PROVISIONER_MTLS_ROOT_CERT")
 }
+
+pub fn get_data_plane_version() -> Result<String, std::env::VarError> {
+    std::env::var("DATA_PLANE_VERSION")
+}

--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -186,12 +186,8 @@ async fn tcp_server() -> Result<()> {
                             "An error occurred while piping the connection over vsock - {e:?}"
                         );
                     }
-                } else {
-                    if let Err(e) = pipe_streams(connection, enclave_stream).await {
-                        eprintln!(
-                            "An error occurred while piping the connection over vsock - {e:?}"
-                        );
-                    }
+                } else if let Err(e) = pipe_streams(connection, enclave_stream).await {
+                    eprintln!("An error occurred while piping the connection over vsock - {e:?}");
                 }
             });
         }

--- a/shared/src/server/proxy_protocol.rs
+++ b/shared/src/server/proxy_protocol.rs
@@ -148,7 +148,6 @@ impl<C: AsyncRead + AsyncWrite + Sync> ProxiedConnection for AcceptedConn<C> {
 #[cfg(test)]
 mod tests {
     use super::ProxiedConnection;
-    use std::net::SocketAddr;
     use tokio::io::AsyncReadExt;
     use tokio_test::io::Builder;
 
@@ -158,10 +157,10 @@ mod tests {
             ppp::v2::Protocol::Stream,
             (
                 "1.2.3.4:80"
-                    .parse::<SocketAddr>()
+                    .parse::<std::net::SocketAddr>()
                     .expect("Infallible - hardcoded"),
                 "5.6.7.8:443"
-                    .parse::<SocketAddr>()
+                    .parse::<std::net::SocketAddr>()
                     .expect("Infallible - hardcoded"),
             ),
         );


### PR DESCRIPTION
# Why
Data planes without the ability to parse proxy protocol will fail to terminate TLS if it its present

# How
- Add a check for an optional env var of the data plane semantic version
- If the version predates proxy protocol support, strip the header from the socket before forwarding
