### PR TITLE
Improve in enclave dns proxy to prevent EAI again errors

### DIFF
--- a/data-plane/src/dns/enclavedns.rs
+++ b/data-plane/src/dns/enclavedns.rs
@@ -9,22 +9,67 @@ use shared::DNS_PROXY_VSOCK_PORT;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
 
+/// Empty struct for the DNS proxy that runs in the data plane
+pub struct EnclaveDnsProxy;
+
+impl EnclaveDnsProxy {
+    pub async fn bind_server() -> Result<(), DNSError> {
+        println!("Starting DNS proxy");
+        let socket = UdpSocket::bind("127.0.0.1:53").await?;
+        let shared_socket = std::sync::Arc::new(socket);
+        let dns_dispatch_timeout = std::time::Duration::from_secs(1);
+
+        // Create a bounded sync channel to send DNS lookups between the Proxy and Driver
+        let (dns_lookup_sender, dns_lookup_receiver) =
+            tokio::sync::mpsc::channel::<(Bytes, SocketAddr)>(250);
+
+        let dns_driver_socket = shared_socket.clone();
+
+        let dns_request_upper_bound = std::time::Duration::from_secs(3);
+        let dns_driver = EnclaveDnsDriver::new(
+            dns_driver_socket,
+            dns_lookup_receiver,
+            dns_request_upper_bound,
+        );
+        tokio::spawn(async move {
+            println!("Starting DNS request driver");
+            dns_driver.start_driver().await;
+            eprintln!("Enclave DNS Driver exiting");
+        });
+
+        loop {
+            let mut buffer = [0; 512];
+            let (amt, src) = shared_socket.recv_from(&mut buffer).await?;
+            let buf = Bytes::copy_from_slice(&buffer[..amt]);
+            let dispatch_result =
+                timeout(dns_dispatch_timeout, dns_lookup_sender.send((buf, src))).await;
+
+            match dispatch_result {
+                Ok(Err(e)) => eprintln!("Error dispatching DNS request: {e:?}"),
+                Err(e) => eprintln!("Timeout dispatching DNS request: {e:?}"),
+                _ => {}
+            };
+        }
+    }
+}
+
 struct EnclaveDnsDriver {
     inner: Arc<UdpSocket>,
     dns_lookup_receiver: Receiver<(Bytes, SocketAddr)>,
-    dns_request_upper_bound: std::time::Duration,
+    dns_request_upper_bound: Duration,
 }
 
 impl EnclaveDnsDriver {
     fn new(
         socket: Arc<UdpSocket>,
         dns_lookup_receiver: Receiver<(Bytes, SocketAddr)>,
-        dns_request_upper_bound: std::time::Duration,
+        dns_request_upper_bound: Duration,
     ) -> Self {
         Self {
             inner: socket,
@@ -35,28 +80,35 @@ impl EnclaveDnsDriver {
 
     async fn start_driver(mut self) {
         while let Some((dns_packet, src_addr)) = self.dns_lookup_receiver.recv().await {
-            let dns_response = match self.perform_dns_lookup(dns_packet).await {
-                Ok(dns_response) => dns_response,
-                Err(e) => {
-                    eprintln!("Failed to perform DNS Lookup: {e}");
-                    continue;
-                }
-            };
+            let request_upper_bound = self.dns_request_upper_bound.clone();
+            let udp_socket = self.inner.clone();
 
-            if let Err(e) = self.inner.send_to(&dns_response, &src_addr).await {
-                eprintln!("Failed to send DNS Response: {e}");
-            }
+            // Create task per DNS lookup
+            tokio::spawn(async move {
+                let dns_response =
+                    match Self::perform_dns_lookup(dns_packet, request_upper_bound).await {
+                        Ok(dns_response) => dns_response,
+                        Err(e) => {
+                            eprintln!("Failed to perform DNS Lookup: {e}");
+                            return;
+                        }
+                    };
+
+                if let Err(e) = udp_socket.send_to(&dns_response, &src_addr).await {
+                    eprintln!("Failed to send DNS Response: {e}");
+                }
+            });
         }
     }
 
     /// Perform a DNS lookup using the proxy running on the Host, storing the resulting IPs in the Data-Plane's cache
-    async fn perform_dns_lookup(&self, dns_packet: Bytes) -> Result<Bytes, DNSError> {
-        // Attempt DNS lookup wth a 5 second timeout, flatten timeout errors into a DNS Error
-        let dns_response = timeout(
-            self.dns_request_upper_bound,
-            Self::forward_dns_lookup(dns_packet),
-        )
-        .await??;
+    async fn perform_dns_lookup(
+        dns_packet: Bytes,
+        request_upper_bound: Duration,
+    ) -> Result<Bytes, DNSError> {
+        // Attempt DNS lookup wth a timeout, flatten timeout errors into a DNS Error
+        let dns_response =
+            timeout(request_upper_bound, Self::forward_dns_lookup(dns_packet)).await??;
 
         let dns = Dns::decode(dns_response.clone())?;
         // No need to cache responses with no IPs, exit early
@@ -126,40 +178,60 @@ impl EnclaveDnsDriver {
     }
 }
 
-/// Empty struct for the DNS proxy that runs in the data plane
-pub struct EnclaveDnsProxy;
+#[cfg(test)]
+mod test {
+    use super::*;
 
-impl EnclaveDnsProxy {
-    pub async fn bind_server() -> Result<(), DNSError> {
-        println!("Starting DNS proxy");
-        let socket = UdpSocket::bind("127.0.0.1:53").await?;
-        let shared_socket = std::sync::Arc::new(socket);
-
-        // Create a bounded sync channel to send DNS lookups between the Proxy and Driver
-        let (dns_lookup_sender, dns_lookup_receiver) =
-            tokio::sync::mpsc::channel::<(Bytes, SocketAddr)>(1000);
-
-        let dns_driver_socket = shared_socket.clone();
-
-        let dns_request_upper_bound = std::time::Duration::from_secs(5);
-        let dns_driver = EnclaveDnsDriver::new(
-            dns_driver_socket,
-            dns_lookup_receiver,
-            dns_request_upper_bound,
-        );
-        tokio::spawn(async move {
-            println!("Starting DNS request driver");
-            dns_driver.start_driver().await;
-            eprintln!("Enclave DNS Driver exiting");
-        });
-
-        loop {
-            let mut buffer = [0; 512];
-            let (amt, src) = shared_socket.recv_from(&mut buffer).await?;
-            let buf = Bytes::copy_from_slice(&buffer[..amt]);
-            if let Err(e) = dns_lookup_sender.try_send((buf, src)) {
-                eprintln!("Error dispatching DNS request in data plane: {e:?}");
-            }
+    fn generate_dummy_dns_response(
+        answer_ip: std::net::Ipv4Addr,
+        domain_name: dns_message_parser::DomainName,
+    ) -> Dns {
+        Dns {
+            id: 0,
+            flags: dns_message_parser::Flags {
+                qr: true,
+                opcode: dns_message_parser::Opcode::Query,
+                aa: true,
+                tc: true,
+                rd: true,
+                ra: true,
+                ad: true,
+                cd: true,
+                rcode: dns_message_parser::RCode::NoError,
+            },
+            questions: vec![dns_message_parser::question::Question {
+                domain_name: domain_name.clone(),
+                q_class: dns_message_parser::question::QClass::ANY,
+                q_type: dns_message_parser::question::QType::A,
+            }],
+            answers: vec![dns_message_parser::rr::RR::A(dns_message_parser::rr::A {
+                domain_name,
+                ttl: 60,
+                ipv4_addr: answer_ip,
+            })],
+            authorities: vec![],
+            additionals: vec![],
         }
+    }
+
+    #[test]
+    fn test_loopback_dns_responses() {
+        let mut dummy_domain_name = dns_message_parser::DomainName::default();
+        dummy_domain_name.append_label("acme").unwrap();
+        dummy_domain_name.append_label("org").unwrap();
+        let dummy_ip_answer = std::net::Ipv4Addr::new(1, 1, 1, 1);
+        let dummy_dns_response =
+            generate_dummy_dns_response(dummy_ip_answer.clone(), dummy_domain_name.clone());
+
+        let loopback_dns_response =
+            EnclaveDnsDriver::create_loopback_dns_response(dummy_dns_response).unwrap();
+        let decoded_dns = Dns::decode(loopback_dns_response).unwrap();
+        let loopback_dns_answer = decoded_dns.answers.first().unwrap();
+        let dns_message_parser::rr::RR::A(a_record) = loopback_dns_answer else {
+          panic!("create_loopback_dns_response changed DNS record type");
+        };
+        assert_ne!(a_record.ipv4_addr, dummy_ip_answer);
+        assert_eq!(a_record.ipv4_addr, std::net::Ipv4Addr::new(127, 0, 0, 1));
+        assert_eq!(a_record.domain_name, dummy_domain_name);
     }
 }

--- a/data-plane/src/dns/error.rs
+++ b/data-plane/src/dns/error.rs
@@ -21,4 +21,6 @@ pub enum DNSError {
     NoHostnameFound,
     #[error("Egress error {0}")]
     EgressError(#[from] EgressError),
+    #[error("DNS lookup failed due to a timeout after: {0}")]
+    DNSTimeout(#[from] tokio::time::error::Elapsed),
 }

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -8,7 +8,7 @@ use data_plane::configuration;
 #[cfg(feature = "network_egress")]
 use data_plane::dns::egressproxy::EgressProxy;
 #[cfg(feature = "network_egress")]
-use data_plane::dns::enclavedns::EnclaveDns;
+use data_plane::dns::enclavedns::EnclaveDnsProxy;
 #[cfg(not(feature = "tls_termination"))]
 use data_plane::env::Environment;
 use data_plane::health::start_health_check_server;
@@ -66,7 +66,7 @@ async fn start(data_plane_port: u16) {
 
     let (_, dns_result, e3_api_result, egress_results, stats_result) = tokio::join!(
         start_data_plane(data_plane_port),
-        EnclaveDns::bind_server(),
+        EnclaveDnsProxy::bind_server(),
         CryptoApi::listen(),
         egress_proxies,
         StatsProxy::listen()

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -143,6 +143,7 @@ pub fn get_egress_ports(port_str: String) -> Vec<u16> {
 #[cfg(test)]
 mod tests {
     use crate::server::egress::get_egress_allow_list;
+    use crate::server::egress::get_egress_allow_list_from_env;
     use crate::server::egress::EgressDomains;
 
     #[test]
@@ -154,7 +155,7 @@ mod tests {
 
     fn test_valid_all_domains() {
         std::env::set_var("EV_EGRESS_ALLOW_LIST", "*");
-        let egress = get_egress_allow_list();
+        let egress = get_egress_allow_list_from_env();
         assert_eq!(
             egress,
             EgressDomains {
@@ -168,7 +169,7 @@ mod tests {
 
     fn test_wildcard_and_exact() {
         std::env::set_var("EV_EGRESS_ALLOW_LIST", "*.evervault.com,google.com");
-        let egress = get_egress_allow_list();
+        let egress = get_egress_allow_list_from_env();
         assert_eq!(
             egress,
             EgressDomains {
@@ -182,7 +183,7 @@ mod tests {
 
     fn test_backwards_compat() {
         std::env::set_var("EV_EGRESS_ALLOW_LIST", "");
-        let egress = get_egress_allow_list();
+        let egress = get_egress_allow_list_from_env();
         assert_eq!(
             egress,
             EgressDomains {

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -142,7 +142,6 @@ pub fn get_egress_ports(port_str: String) -> Vec<u16> {
 
 #[cfg(test)]
 mod tests {
-    use crate::server::egress::get_egress_allow_list;
     use crate::server::egress::get_egress_allow_list_from_env;
     use crate::server::egress::EgressDomains;
 


### PR DESCRIPTION
# Why
DNS Proxy in the data plane was handling lookups sequentially so was able to be choked by a failed lookup.

# How
- Update Data plane's DNS Proxy to have better concurrency support (up to 250 lookups at a time)
- Add timeouts for all networking and sync channels within the DNS Proxy
- Add logs for observability into the DNS Proxy

## Note
There is a concurrency control applied using a semaphore (to prevent FD exhaustion) and an upper bound on the buffer of the DNS proxy's internal sync channel (to prevent an unbounded message buffer).