### PR TITLE
Add call to get metadata token before calling for instance id

### DIFF
--- a/scripts/start-cage.sh
+++ b/scripts/start-cage.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-INSTANCE_ID=$(curl http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r ."instanceId")
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -sL`
+INSTANCE_ID=$(curl http://169.254.169.254/latest/dynamic/instance-identity/document -H "X-aws-ec2-metadata-token: $TOKEN" | jq -r ."instanceId")
 
 export EC2_INSTANCE_ID=${INSTANCE_ID}
 


### PR DESCRIPTION
# Why
Cage startup script calls the EC2 metadata API to get the current instance ID, but this call is failing due to a missing auth token

# How
Add call to get short lived metadata token before calling for instance ID
