### PR TITLE
[SPE-780] Add config client methods for storage

### DIFF
--- a/data-plane/src/config_client.rs
+++ b/data-plane/src/config_client.rs
@@ -6,8 +6,9 @@ use hyper::{Body, Response};
 use serde::de::DeserializeOwned;
 use shared::logging::TrxContext;
 use shared::server::config_server::requests::{
-    ConfigServerPayload, GetCertTokenResponseDataPlane, GetE3TokenResponseDataPlane,
-    GetTokenRequestDataPlane, PostTrxLogsRequest,
+    ConfigServerPayload, DeleteObjectRequest, GetCertTokenResponseDataPlane,
+    GetE3TokenResponseDataPlane, GetObjectRequest, GetObjectResponse, GetTokenRequestDataPlane,
+    PostTrxLogsRequest, PutObjectRequest,
 };
 use shared::server::config_server::routes::ConfigServerPath;
 
@@ -117,6 +118,50 @@ impl ConfigClient {
             println!("Error in message send to control plane");
             Err(Error::ConfigServer(
                 "Invalid Response code returned when sending trx logs to control plane "
+                    .to_string(),
+            ))
+        }
+    }
+
+    pub async fn get_object(&self, key: String) -> Result<GetObjectResponse> {
+        let payload = GetObjectRequest::new(key).into_body()?;
+
+        let response = self.send(ConfigServerPath::Storage, "GET", payload).await?;
+
+        let result: GetObjectResponse = self.parse_response(response).await?;
+
+        Ok(result)
+    }
+
+    pub async fn put_object(&self, key: String, object: String) -> Result<()> {
+        let payload = PutObjectRequest::new(key, object).into_body()?;
+
+        let response = self.send(ConfigServerPath::Storage, "PUT", payload).await?;
+
+        if response.status() == StatusCode::OK {
+            Ok(())
+        } else {
+            println!("Error in message send to control plane");
+            Err(Error::ConfigServer(
+                "Invalid Response code returned when sending putObject request to control plane "
+                    .to_string(),
+            ))
+        }
+    }
+
+    pub async fn delete_object(&self, key: String) -> Result<()> {
+        let payload = DeleteObjectRequest::new(key).into_body()?;
+
+        let response = self
+            .send(ConfigServerPath::Storage, "DELETE", payload)
+            .await?;
+
+        if response.status() == StatusCode::OK {
+            Ok(())
+        } else {
+            println!("Error in message send to control plane.");
+            Err(Error::ConfigServer(
+                "Invalid Response code returned when sending deleteObject request to control plane"
                     .to_string(),
             ))
         }


### PR DESCRIPTION
# Why
Need the methods in the config client in the data plane to send requests through the control plane under to S3.

# How
Added the methods which need to be used to persist acme materials:
 - get_object
 - put_object 
 - delete_object 
