### PR TITLE
Restructure Cages CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --features not_enclave -- -D warnings  
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/test-control-plane.yml
+++ b/.github/workflows/test-control-plane.yml
@@ -2,10 +2,11 @@ on:
   push:
     paths:
       - control-plane/**
-      - .github/workflows/lint-and-test-control-plane.yml
-name: Lint and Test Control Plane
+      - shared/**
+      - .github/workflows/test-control-plane.yml
+name: Test Control Plane
 jobs:
-  clippy_check_control_plane:
+  test_control_plane:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +23,3 @@ jobs:
         run: cargo build --features not_enclave,network_egress -p control-plane 
       - name: Test project
         run: cargo test --features enclave,network_egress -p control-plane
-      - name: Format project
-        run: cargo fmt --check

--- a/.github/workflows/test-data-plane.yml
+++ b/.github/workflows/test-data-plane.yml
@@ -2,24 +2,11 @@ on:
   push:
     paths:
       - data-plane/**
-      - .github/workflows/lint-and-test-data-plane.yml
-name: Lint and Test Data Plane
+      - shared/**
+      - .github/workflows/test-data-plane.yml
+name: Test Data Plane
 jobs:
-  lint_data_plane:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "standard-cache"
-      - name: Format project
-        run: cargo fmt --check
   check_data_plane:
-    needs: [lint_data_plane]
     strategy:
       matrix:
         feature-flags:
@@ -46,7 +33,7 @@ jobs:
         run: cargo check -p data-plane --no-default-features --features ${{ matrix.feature-flags }}
 
   test_data_plane:
-    needs: [lint_data_plane, check_data_plane]
+    needs: [check_data_plane]
     strategy:
       matrix:
         feature-flags:

--- a/.github/workflows/test-shared-lib.yml
+++ b/.github/workflows/test-shared-lib.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    paths:
+      - shared/**
+      - .github/workflows/test-shared-lib.yml
+name: Test Shared Library
+jobs:
+  test_shared_lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "standard-cache"
+      - name: Compile project
+        run: cargo check -p shared --no-default-features --features network_egress
+      - name: Test project
+        run: cargo test -p shared --no-default-features --features network_egress


### PR DESCRIPTION
# Why
Cages CI had a lot of repetition:
- We had a common lint workflow, but each package also ran its own linter
- The shared library never triggered a test/compile on the control-plane/data-plane
- The shared library wasn't tested

# How
- Remove lint step from individual packages
- Add trigger for control plane and data plane CI for changes to shared lib
- Add shared lib CI
