### PR TITLE
Return 401 for websockets

### DIFF
--- a/control-plane/src/e3proxy.rs
+++ b/control-plane/src/e3proxy.rs
@@ -67,7 +67,7 @@ impl E3Proxy {
                     Self::shutdown_conn(connection).await;
                     continue;
                 }
-            }; // TODO: cache
+            };
             println!("IP for E3 obtained: {e3_ip}");
             tokio::spawn(async move {
                 let e3_stream = match tokio::net::TcpStream::connect(e3_ip).await {

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -95,11 +95,12 @@ where
                         });
                         let not_http = req.method.is_none();
                         if is_websocket || not_http {
-                            //TODO: send 401 response
                             if let Err(err) =
                                 auth_request_non_http(headers, e3_client_for_tcp.clone()).await
                             {
                                 eprintln!("Failed to authenticate request — {err:?}");
+                                let unauth_resp = build_401_response().await;
+                                let _ = stream.write_all(&unauth_resp).await;
                                 shutdown_conn(&mut stream).await;
                                 break;
                             }
@@ -168,6 +169,14 @@ where
             }
         });
     }
+}
+
+async fn build_401_response() -> Vec<u8> {
+    let response = Response::builder()
+        .status(401)
+        .body(Body::empty())
+        .expect("infallible");
+    response_to_bytes(response).await
 }
 
 async fn auth_request_non_http(

--- a/e2e-tests/websocketTests.js
+++ b/e2e-tests/websocketTests.js
@@ -1,9 +1,10 @@
 const { expect } = require('chai');
+const assert = require('assert');
 const WebSocket = require('ws');
 
 describe('Make websocket request', () => {
 
-    it('should output success exit code', async () => {
+    it('should start websocket session', async () => {
         const options = {
             rejectUnauthorized: false,
             headers: {
@@ -26,6 +27,29 @@ describe('Make websocket request', () => {
             socket.close()
         });
         
+    })
+
+    it('should start websocket session', async () => {
+        const options = {
+            rejectUnauthorized: false
+        };
+
+        const serverUrl = 'wss://localhost:443/hello';
+
+        const socket = new WebSocket(serverUrl, options);
+
+        socket.on('open', () => {
+            console.log('Connected to WebSocket server');
+            socket.send('test connection');
+        });
+
+        socket.on('error', (err) => {
+            expect(err.message).to.equal("Unexpected server response: 401");
+        });  
+
+        socket.on('message', (data) => {
+            assert.fail('Connection was sucessful, 401 expected');
+        });
     })
 
 });

--- a/e2e-tests/websocketTests.js
+++ b/e2e-tests/websocketTests.js
@@ -4,7 +4,7 @@ const WebSocket = require('ws');
 
 describe('Make websocket request', () => {
 
-    it('should start websocket session', async () => {
+    it('should start websocket session when authorised', async () => {
         const options = {
             rejectUnauthorized: false,
             headers: {
@@ -29,7 +29,7 @@ describe('Make websocket request', () => {
         
     })
 
-    it('should start websocket session', async () => {
+    it('should not start websocket session when not authorised', async () => {
         const options = {
             rejectUnauthorized: false
         };


### PR DESCRIPTION
# Why
Return 401 for unauthed websocket requests

# How
Return 401 response
