### PR TITLE
Non http trx logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "cadence",
  "chrono",
  "derive_builder",
+ "httparse",
  "hyper",
  "lazy_static",
  "ppp",

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -69,6 +69,8 @@ pub enum Error {
     NonHttpAuthError,
     #[error("trx context builder error = {0}")]
     TrxContextBuilderError(#[from] TrxContextBuilderError),
+    #[error("Failed to send trx log= {0}")]
+    FailedToSendTrxLog(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -1,5 +1,5 @@
 use hyper::header::{InvalidHeaderName, InvalidHeaderValue};
-use shared::server::error::ServerError;
+use shared::{logging::TrxContextBuilderError, server::error::ServerError};
 use thiserror::Error;
 
 use crate::{base_tls_client::ClientError, env::EnvError, CageContextError};
@@ -67,6 +67,8 @@ pub enum Error {
     ApiKeyInvalid,
     #[error("API key auth must be switched off for non http requests")]
     NonHttpAuthError,
+    #[error("trx context builder error = {0}")]
+    TrxContextBuilderError(#[from] TrxContextBuilderError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
     MissingApiKey,
     #[error("Api key is invalid")]
     ApiKeyInvalid,
+    #[error("API key auth must be switched off for non http requests")]
+    NonHttpAuthError,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -168,6 +168,7 @@ where
             Err(_) => {
                 let unauth_resp = build_401_response().await;
                 stream.write_all(&unauth_resp).await?;
+                shutdown_conn(stream).await;
                 Ok(())
             }
         }
@@ -183,6 +184,7 @@ where
         .await?;
         let response_bytes = response_to_bytes(response).await;
         stream.write_all(&response_bytes).await?;
+        shutdown_conn(stream).await;
         Ok(())
     }
 }

--- a/data-plane/src/utils/trx_handler.rs
+++ b/data-plane/src/utils/trx_handler.rs
@@ -56,6 +56,7 @@ impl LogHandlerBuffer {
     // Removes logs from the buffer and sends them to the control plane
     pub async fn send_logs(&mut self) {
         let trx_logs: Vec<TrxContext> = self.buffer.drain(..).collect();
+        println!("LOGSSS:::: {:?}", trx_logs);
         if let Err(err) = self.config_client.post_trx_logs(trx_logs).await {
             println!("Failed to ship trx logs to control plane. {err:?}");
         };

--- a/data-plane/src/utils/trx_handler.rs
+++ b/data-plane/src/utils/trx_handler.rs
@@ -56,7 +56,6 @@ impl LogHandlerBuffer {
     // Removes logs from the buffer and sends them to the control plane
     pub async fn send_logs(&mut self) {
         let trx_logs: Vec<TrxContext> = self.buffer.drain(..).collect();
-        println!("LOGSSS:::: {:?}", trx_logs);
         if let Err(err) = self.config_client.post_trx_logs(trx_logs).await {
             println!("Failed to ship trx logs to control plane. {err:?}");
         };

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -26,6 +26,7 @@ ppp = { version = "2.2.0" }
 tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration"] }
 sys-info = "0.9.1"
 cadence = "0.29.0"
+httparse = "1.8.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/shared/src/logging.rs
+++ b/shared/src/logging.rs
@@ -19,9 +19,9 @@ pub struct TrxContext {
     txid: String,
     ts: String,
     msg: String,
-    uri: String,
+    uri: Option<String>,
     r#type: String,
-    request_method: String,
+    request_method: Option<String>,
     #[builder(default)]
     remote_ip: Option<String>,
     #[builder(default)]
@@ -155,8 +155,8 @@ impl TrxContextBuilder {
     }
 
     pub fn add_req_to_trx_context(&mut self, req: &Request<Body>, trusted_headers: &[String]) {
-        self.uri(build_log_uri(req.uri()));
-        self.request_method(req.method().to_string());
+        self.uri(Some(build_log_uri(req.uri())));
+        self.request_method(Some(req.method().to_string()));
         self.add_headers_to_request(req.headers(), trusted_headers);
 
         //Pull out content type


### PR DESCRIPTION
# Why
Add logs for non HTTP requests

# How
- For WS request, add all HTTP info that comes in upgrade request
- Log only if log creation/send fails, dont affect request
- Any other request will be classified as TCP as catchall
- No response info or request times because we blind pipe non http requests 
- Added 401 status code for non HTTP requests when auth fails - kind of weird for TCP case, can change if people feel strongly about it but can format this differently in the UI because the enum will specify the request type
