### PR TITLE
markd/handle requests to .well-known/attestation

### DIFF
--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     TrxContextBuilderError(#[from] TrxContextBuilderError),
     #[error("Failed to send trx log= {0}")]
     FailedToSendTrxLog(String),
+    #[error("Failed to return attestation document - {0:?}")]
+    AttestationRequestError(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -449,8 +449,10 @@ impl ToString for AttestationChallenge {
 
 #[cfg(feature = "enclave")]
 async fn handle_attestation_request(_req: httparse::Request<'_, '_>) -> Result<Response<Body>> {
+    use chrono::Duration;
+
     let challenge = AttestationChallenge {
-        expiry: Utc::now().to_string(),
+        expiry: (Utc::now() + Duration::minutes(15)).to_string(),
     }
     .to_string()
     .as_bytes()


### PR DESCRIPTION
# Why
In the new attestation flow we want the attestation document available to clients at <cage-url>/.well-known/attestation.

The AD will now contain the cage's cert and an expiry time

# How

Break out of normal request handling flow on requests to .well-known and handle seperately
