### PR TITLE
Update data plane request parsing

### DIFF
--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     TrxContextBuilderError(#[from] TrxContextBuilderError),
     #[error("Failed to send trx log= {0}")]
     FailedToSendTrxLog(String),
+    #[error("Request timed out in data plane after {0} seconds")]
+    RequestTimeout(usize),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
# Why
Data plane request parsing wasn't accounting for content length, resulting intermittent incomplete bodies being forwarded to wrapped services.

# How
Update `build_http_request` to take in the incoming stream, evaluate the content length, and read until the full payload is in memory before forwarding
