### PR TITLE
chore: move to rustls maintained webpki crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
  "hyper-rustls",
  "lazy_static",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "tower",
  "tracing",
@@ -741,7 +741,7 @@ dependencies = [
  "thiserror",
  "tls-parser",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-test",
  "tokio-vsock",
  "trust-dns-resolver",
@@ -972,7 +972,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-test",
  "tokio-util 0.6.10",
  "tokio-vsock",
@@ -1382,10 +1382,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2160,6 +2160,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2393,7 +2415,7 @@ dependencies = [
  "thiserror",
  "tls-parser",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-test",
  "tokio-vsock",
 ]
@@ -2637,9 +2659,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.7",
+ "tokio",
 ]
 
 [[package]]

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -12,7 +12,7 @@ dns-message-parser = { version = "~0.6.0" }
 bytes = "1"
 thiserror = "1.0"
 tokio-vsock = { version = "0.3.2", optional = true }
-tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration"] }
+tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 tls-parser = "*"
 shared = { path = "../shared" }
 rand = { version = "0.8.5" }

--- a/control-plane/src/clients/cert_provisioner.rs
+++ b/control-plane/src/clients/cert_provisioner.rs
@@ -49,7 +49,7 @@ fn get_mtls_connector(
     let (client_cert_chain, client_key) = client_key_pair;
     let mtls_connector_config = base_config_builder
         .with_root_certificates(root_store)
-        .with_single_cert(client_cert_chain, client_key)
+        .with_client_auth_cert(client_cert_chain, client_key)
         .expect("Failed to add client cert for making connector to cert provisioner");
 
     tokio_rustls::TlsConnector::from(std::sync::Arc::new(mtls_connector_config))


### PR DESCRIPTION
# Why
Webpki has a known vulnerability reported in [webpki#69](https://github.com/briansmith/webpki/issues/69). The rustls team have forked webpki for their own create, which is used from rustls 0.24.0 onwards.

# How
Updating rustls dependency to remove dep on vulnerable webpki crate