### PR TITLE
Update tls server to advertise http/1.1 and http2 in alpn

### DIFF
--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -75,7 +75,7 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
             super::cert_resolver::AttestableCertResolver::new(ca_cert, ca_private_key)?;
         let mut tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));
-        tls_config.alpn_protocols = vec![b"http/1.1".to_vec(),b"h2".to_vec()];
+        tls_config.alpn_protocols = vec![b"http/1.1".to_vec(), b"h2".to_vec()];
         Ok(TlsServer::new(tls_config, self.tcp_server))
     }
 

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -73,8 +73,9 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
         println!("Received intermediate CA from cert provisioner. Using it with TLS Server.");
         let attestable_cert_resolver =
             super::cert_resolver::AttestableCertResolver::new(ca_cert, ca_private_key)?;
-        let tls_config =
+        let mut tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));
+        tls_config.alpn_protocols = vec![b"http/1.1".to_vec(),b"h2".to_vec()];
         Ok(TlsServer::new(tls_config, self.tcp_server))
     }
 


### PR DESCRIPTION
# Why
gRPC clients currently reject the connection to a Cage as the server doesn't include h2 support in it's alpn protocols

# How
Specify http/1.1 and h2 support in the server's TLS config
