### PR TITLE
Bump storage-client-interface which has logs

### DIFF
--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -33,7 +33,7 @@ mockall = "0.11.4"
 axum = "0.6.19"
 openssl = { version = "0.10.48", features = ["vendored"] }
 base64 = "0.13.0"
-storage-client-interface = "0.1.0"
+storage-client-interface = "0.2.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"


### PR DESCRIPTION
# Why
S3 calls failing with no error message

# How
Bump to version which logs
