### PR TITLE
Add debug log to see certificate before parsed and encrypted

### DIFF
--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -312,6 +312,8 @@ impl AcmeCertificateRetreiver {
                 "Certificate not found in completed order".into(),
             ))?;
 
+        println!("Certificate received from ACME provider: {:?}", cert_chain);
+
         RawAcmeCertificate::from_x509s(cert_chain)
     }
 


### PR DESCRIPTION
# Why
Certificates are being provisioned and stored in the cage but the encoding is wrong and the TLS handshake fails. The cert returned from E3 decrypted isn't matching the cert pulled directly from zerossl 

```bash
curl https://trustable-cage.app-511b16ff81fa.cage.evervault.dev/decrypt -H "Content-Type: application/json"                                                                                             
curl: (35) LibreSSL/3.3.6: error:0DFFF0A8:asn1 encoding routines:CRYPTO_internal:wrong tag
```

# How
Print certs as they're received from zerossl to debug