### PR TITLE
Move writing init complete vars to after trusted cert

### DIFF
--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -1,4 +1,7 @@
-use std::{fs::File, io::Write};
+use std::{
+    fs::{File, OpenOptions},
+    io::Write,
+};
 
 #[cfg(not(feature = "tls_termination"))]
 use crate::cert_provisioner_client::CertProvisionerClient;
@@ -104,15 +107,14 @@ impl Environment {
     }
 
     pub fn write_startup_complete_env_vars() -> Result<(), EnvError> {
-        let mut existing_file = File::open("/etc/customer-env")?;
-        let mut env_string = "".to_owned();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open("/etc/customer-env")?;
 
-        // Set var to let customer process know the env is ready and it can start up
-        env_string.push_str("export EV_CAGE_INITIALIZED=true");
-        // Backwards compatibility for customers that are still using old versions of the CLI - remove after full launch
-        env_string.push_str("export EV_API_KEY=placeholder");
+        write!(file, "export EV_CAGE_INITIALIZED=true  ")?;
+        write!(file, "export EV_API_KEY=placeholder")?;
 
-        existing_file.write_all(env_string.as_bytes())?;
         Ok(())
     }
 }

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -98,12 +98,21 @@ impl Environment {
             let value = &format!("export {}={}  ", env.name, env.secret);
             env_string.push_str(value)
         });
+
+        file.write_all(env_string.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn write_startup_complete_env_vars() -> Result<(), EnvError> {
+        let mut existing_file = File::open("/etc/customer-env")?;
+        let mut env_string = "".to_owned();
+
         // Set var to let customer process know the env is ready and it can start up
         env_string.push_str("export EV_CAGE_INITIALIZED=true");
         // Backwards compatibility for customers that are still using old versions of the CLI - remove after full launch
         env_string.push_str("export EV_API_KEY=placeholder");
 
-        file.write_all(env_string.as_bytes())?;
+        existing_file.write_all(env_string.as_bytes())?;
         Ok(())
     }
 }

--- a/data-plane/src/server/error.rs
+++ b/data-plane/src/server/error.rs
@@ -22,6 +22,7 @@ pub enum TlsError {
     CageContextError(#[from] CageContextError),
     SystemTimeError(#[from] SystemTimeError),
     TryFromIntError(#[from] TryFromIntError),
+    EnvError(#[from] crate::env::EnvError),
 }
 
 impl std::fmt::Display for TlsError {

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -19,6 +19,7 @@ use super::inter_ca_retreiver;
 #[cfg(feature = "enclave")]
 use crate::acme;
 
+use crate::env::Environment;
 use crate::server::error::ServerResult;
 use crate::server::error::TlsError;
 use rand::Rng;
@@ -85,6 +86,9 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
 
         #[cfg(not(feature = "enclave"))] // Don't order trusted certs locally
         let trusted_cert: Option<CertifiedKey> = None;
+
+        //Once intermediate cert and trusted cert retrieved, write cage initialised vars
+        Environment::write_startup_complete_env_vars()?;
 
         let attestable_cert_resolver = super::cert_resolver::AttestableCertResolver::new(
             ca_cert,


### PR DESCRIPTION
# Why
If ordering a trusted cert fails, the ecs health check still reports as healthy as the EV_CAGE_INITIALIZED var has been written which makes the cage pass health checks.

# How
Move writing the `EV_CAGE_INITIALIZED` to after trusted cert is ordered.
