### PR TITLE
Update cages tls server to include http2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,9 +2798,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-client-interface"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b08a105d82187d3aedb4229ba193dfa34ff8519ec6d979985a367c9598d0a9"
+checksum = "d9a0c730d9a59eb3f2e9c8bf399fa90176e248367193bbb215aeba999fc88f93"
 dependencies = [
  "async-trait",
  "aws-config 0.56.1",

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -91,8 +91,9 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
             ca_private_key,
             trusted_cert,
         )?;
-        let tls_config =
+        let mut tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));
+        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         Ok(TlsServer::new(tls_config, self.tcp_server))
     }
 


### PR DESCRIPTION
# Why
Want to support http2 in Cages

# How
Add tls alpn protocol list in the data plane. This will give preference to HTTP/2, falling back to http/1.1.
