### PR TITLE
[SPE-846] Don't write env init var returned from provisioner

### DIFF
--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -90,6 +90,10 @@ impl Environment {
         CageContext::set(cert_response.clone().context.into());
 
         self.init(cert_response.clone().secrets).await?;
+
+        //Write vars to indicate cage is initialised
+        Self::write_startup_complete_env_vars();
+
         Ok(())
     }
 

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -99,9 +99,9 @@ impl Environment {
         let env_string = secrets
             .iter()
             .filter(|env| env.name != "EV_CAGE_INITIALIZED")
-            .map(|env| format!("export {}={}", env.name, env.secret))
+            .map(|env| format!("export {}={}  ", env.name, env.secret))
             .collect::<Vec<_>>()
-            .join("  ");
+            .join("");
 
         file.write_all(env_string.as_bytes())?;
         Ok(())

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -96,7 +96,8 @@ impl Environment {
     fn write_env_file(self, secrets: Vec<Secret>) -> Result<(), EnvError> {
         let mut file = File::create("/etc/customer-env")?;
 
-        let env_string = secrets.iter()
+        let env_string = secrets
+            .iter()
             .filter(|env| env.name != "EV_CAGE_INITIALIZED")
             .map(|env| format!("export {}={}", env.name, env.secret))
             .collect::<Vec<_>>()

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -95,12 +95,12 @@ impl Environment {
 
     fn write_env_file(self, secrets: Vec<Secret>) -> Result<(), EnvError> {
         let mut file = File::create("/etc/customer-env")?;
-        let mut env_string: String = "".to_owned();
 
-        secrets.iter().for_each(|env| {
-            let value = &format!("export {}={}  ", env.name, env.secret);
-            env_string.push_str(value)
-        });
+        let env_string = secrets.iter()
+            .filter(|env| env.name != "EV_CAGE_INITIALIZED")
+            .map(|env| format!("export {}={}", env.name, env.secret))
+            .collect::<Vec<_>>()
+            .join("  ");
 
         file.write_all(env_string.as_bytes())?;
         Ok(())

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -100,7 +100,7 @@ impl Environment {
             .iter()
             .filter(|env| env.name != "EV_CAGE_INITIALIZED")
             .map(|env| format!("export {}={}  ", env.name, env.secret))
-            .collect::<Vec<_>>()
+            .collect::<Vec<String>>()
             .join("");
 
         file.write_all(env_string.as_bytes())?;
@@ -114,7 +114,7 @@ impl Environment {
             .open("/etc/customer-env")?;
 
         write!(file, "export EV_CAGE_INITIALIZED=true  ")?;
-        write!(file, "export EV_API_KEY=placeholder")?;
+        write!(file, "export EV_API_KEY=placeholder  ")?;
 
         Ok(())
     }


### PR DESCRIPTION
# Why
The provisioner returns the `EV_CAGE_INITIALIZED` env var. We now need to delay that been written until the trusted cert has also being provisioned/returned. 

# How
Filter it out of secrets returned from provisioner. Ideally we could've removed it from the provisioner but older runtimes depend upon it being there
