### PR TITLE
[SPE-884] Strip transfer encoding header on response in data plane

### DIFF
--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -439,6 +439,9 @@ async fn handle_http_request(
     trx_context.add_res_to_trx_context(&response, trusted_headers.as_ref());
     let built_context = trx_context.stop_timer_and_build(request_timer);
 
+    //Strip transfer encoding header as hyper client is building chunked response before returning. Temp fix, should supported passing chunked bytes back to client
+    response.headers_mut().remove("transfer-encoding");
+
     match built_context {
         Ok(ctx) => {
             if trx_logging_enabled {

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -10,6 +10,7 @@ describe("POST data to enclave", () => {
       rejectUnauthorized: false,
     }),
   });
+
   it("enclave responds and echos back body", () => {
     return allowAllCerts
       .post(
@@ -128,6 +129,28 @@ describe("POST data to enclave", () => {
         PCR8: "000",
       },
     });
+  });
+
+  it("enclave responds and echos back body without transfer-encoding", () => {
+    return allowAllCerts
+      .post(
+        "https://cage.localhost:443/chunked",
+        { secret: "ev:123" },
+        { headers: { "api-key": "placeholder" } }
+      )
+      .then((result) => {
+        console.log("Post request sent to the enclave");
+        expect(result.data).to.deep.equal({
+          response: "Hello from enclave",
+          secret: "ev:123",
+        });
+        //check transfer-encoding is not set
+        expect(result.headers['transfer-encoding']).to.be.undefined;
+      })
+      .catch((err) => {
+        console.error(err);
+        throw err;
+      });
   });
 });
 

--- a/e2e-tests/httpCustomerProcess.js
+++ b/e2e-tests/httpCustomerProcess.js
@@ -79,6 +79,29 @@ app.post('/attestation-doc', async (req, res) => {
 })
 
 
+app.all("/chunked", async (req, res) => {
+  try {
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('transfer-encoding', 'chunked');
+    const responseData = { response: 'Hello from enclave', ...req.body };
+
+    const jsonStr = JSON.stringify(responseData);
+
+    const chunkSize = 20;
+
+    for (let i = 0; i < jsonStr.length; i += chunkSize) {
+      const chunk = jsonStr.slice(i, i + chunkSize);
+      res.write(chunk);
+    }
+
+    res.end();
+  } catch (err) {
+    console.log("Could not handle hello request", err);
+    res.status(500).send({msg: "Error from within the cage!"})
+  }
+});
+
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)
 })


### PR DESCRIPTION
# Why
Data plane is using a hyper client to forward requests into the user process. When the response is chunked, the hyper client is building the chunked response and returning it complete. The transfer encoding header is still being returned however which breaks when received by the client. 

# How
Remove transfer-encoding header on response returned from user process. Short term fix, long term would be to support passing a chunked stream back to the end user. 
