### PR TITLE
Add vsock proxy crate

### DIFF
--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Check project
         run: cargo check -p vsock-proxy
       - uses: actions-rs/clippy-check@v1
+        with:
+          args: -p vsock-proxy
       - name: Check formatting
         run: cargo fmt --check
+
   test-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy]
@@ -38,6 +41,7 @@ jobs:
           shared-key: "vsock-proxy"
       - name: Test vsock proxy
         run: cargo test -p vsock-proxy
+
   build-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy,test-proxy]
@@ -54,6 +58,7 @@ jobs:
         with:
           name: vsock-proxy
           path: target/release/vsock-proxy
+          
   release-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy, test-proxy, build-proxy]

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    paths:
+      - crates/vsock-proxy/**
+      - shared/**
+      - .github/workflows/vsock-proxy.yml
+name: vsock-proxy
+jobs:
+  check-proxy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "vsock-proxy"
+      - name: Check project
+        run: cargo check -p vsock-proxy
+  test-proxy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "vsock-proxy"
+      - name: Test vsock proxy
+        run: cargo test -p vsock-proxy
+  build-proxy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compile proxy
+        run: cargo build -p vsock-proxy --release
+      - name: Upload proxy
+        uses: actions/upload-artifact@v2
+        with:
+          name: vsock-proxy
+          path: target/release/vsock-proxy
+      

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           args: -p vsock-proxy
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check formatting
         run: cargo fmt --check
 
@@ -58,7 +59,7 @@ jobs:
         with:
           name: vsock-proxy
           path: target/release/vsock-proxy
-          
+
   release-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy, test-proxy, build-proxy]

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -21,6 +21,9 @@ jobs:
           shared-key: "vsock-proxy"
       - name: Check project
         run: cargo check -p vsock-proxy
+      - uses: actions-rs/clippy-check@v1
+      - name: Check formatting
+        run: cargo fmt --check
   test-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy]

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -20,6 +20,7 @@ jobs:
         run: cargo check -p vsock-proxy
   test-proxy:
     runs-on: ubuntu-latest
+    needs: [check-proxy]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -32,7 +33,12 @@ jobs:
         run: cargo test -p vsock-proxy
   build-proxy:
     runs-on: ubuntu-latest
+    needs: [check-proxy,test-proxy]
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Compile proxy
         run: cargo build -p vsock-proxy --release
       - name: Upload proxy

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -1,4 +1,6 @@
 on:
+  release:
+    types: [published]
   push:
     paths:
       - crates/vsock-proxy/**
@@ -8,6 +10,7 @@ name: vsock-proxy
 jobs:
   check-proxy:
     runs-on: ubuntu-latest
+    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -21,6 +24,7 @@ jobs:
   test-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy]
+    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -34,6 +38,7 @@ jobs:
   build-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy,test-proxy]
+    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -46,4 +51,16 @@ jobs:
         with:
           name: vsock-proxy
           path: target/release/vsock-proxy
-      
+  release-proxy:
+    runs-on: ubuntu-latest
+    needs: [check-proxy, test-proxy, build-proxy]
+    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Publish vsock-proxy
+        run: cargo publish -p vsock-proxy
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1015,6 +1063,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1098,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "control-plane"
@@ -2332,22 +2413,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3354,6 +3435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,6 +3475,19 @@ checksum = "e32675ee2b3ce5df274c0ab52d19b28789632406277ca26bffee79a8e27dc133"
 dependencies = [
  "libc",
  "nix 0.23.2",
+]
+
+[[package]]
+name = "vsock-proxy"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "clap",
+ "pin-project",
+ "shared",
+ "thiserror",
+ "tokio",
+ "tokio-vsock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["control-plane","data-plane", "shared"]
+members = ["control-plane","data-plane","shared","crates/*"]
 exclude = ["./e2e-tests/mock-crypto"]

--- a/crates/vsock-proxy/Cargo.toml
+++ b/crates/vsock-proxy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vsock-proxy"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.73"
+clap = "4.4.6"
+pin-project = "1.1.3"
+shared = { path = "../../shared" }
+thiserror = "1.0.30"
+tokio = { version = "1.12.0", features = ["net", "rt", "io-util"] }
+tokio-vsock = "0.3.2"

--- a/crates/vsock-proxy/README.md
+++ b/crates/vsock-proxy/README.md
@@ -1,0 +1,23 @@
+# vsock-proxy
+
+A utility crate for proxying connections between TCP and Vsock.
+
+## Install
+
+```sh
+cargo install vsock-proxy
+```
+
+## Examples
+
+### Proxy from TCP to VSock
+
+```sh
+vsock-proxy --tcp-source 127.0.0.1:8008 --vsock-dest 1234:5678
+```
+
+### Proxy from VSock to TCP
+
+```sh
+vsock-proxy --vsock-source 3:6789 --tcp-dest 127.0.0.1:5000
+```

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -1,201 +1,9 @@
 use clap::{Arg, Command};
+
+mod net;
+
+use net::{Address, Error};
 use shared::server::Listener;
-use std::{net::AddrParseError, num::ParseIntError};
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-enum VsockParseError {
-    #[error(
-        "Failed to parse vsock address. Incorrect number of tokens found. Expected 2, Received {0}"
-    )]
-    InvalidAddress(usize),
-    #[error("Failed to parse tokens in vsock address. Expected 2 numeric tokens separated by a colon (CID:PORT) e.g. 1234:8008")]
-    TokenParseError(#[from] ParseIntError),
-}
-
-#[derive(Debug, Error)]
-enum Error {
-    #[error("Failed to parse tcp socket address - {0}")]
-    TcpParseError(#[from] AddrParseError),
-    #[error(transparent)]
-    VsockParseError(#[from] VsockParseError),
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum Address {
-    Vsock(u32, u32),
-    Tcp(std::net::SocketAddr),
-}
-
-impl Address {
-    fn new_tcp_address(addr: &str) -> Result<Self, Error> {
-        let socket_addr = addr.parse()?;
-        Ok(Self::Tcp(socket_addr))
-    }
-
-    fn new_vsock_address(addr: &str) -> Result<Self, Error> {
-        let addr_parts: Vec<&str> = addr.split(':').collect();
-        if addr_parts.len() != 2 {
-            return Err(Error::VsockParseError(VsockParseError::InvalidAddress(
-                addr_parts.len(),
-            )));
-        }
-
-        let parsed_cid = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
-            Ok(cid) => cid,
-            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
-        };
-
-        let parsed_port = match addr_parts.get(1).unwrap().trim().parse::<u32>() {
-            Ok(port) => port,
-            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
-        };
-
-        Ok(Self::Vsock(parsed_cid, parsed_port))
-    }
-
-    async fn into_listener(self) -> Result<SourceConnection, tokio::io::Error> {
-      match self {
-        Self::Tcp(tcp_addr) => {
-          let listener = tokio::net::TcpListener::bind(tcp_addr).await?;
-          Ok(SourceConnection::Tcp(listener))
-        },
-        Self::Vsock(cid, port) => {
-          let listener = tokio_vsock::VsockListener::bind(cid, port)?;
-          Ok(SourceConnection::Vsock(listener))
-        }
-      }
-    }
-
-    async fn into_destination_connection(&self) -> Result<Connection, tokio::io::Error> {
-      match self {
-        Self::Tcp(tcp_addr) => {
-          let socket = tokio::net::TcpStream::connect(tcp_addr).await?;
-          Ok(Connection::Tcp(socket))
-        },
-        Self::Vsock(cid, port) => {
-          let socket = tokio_vsock::VsockStream::connect(*cid, *port).await?;
-          Ok(Connection::Vsock(socket))
-        }
-      }
-    }
-}
-
-#[cfg(test)] 
-mod test {
-  use super::Address;
-  use std::net::{SocketAddr, IpAddr, Ipv4Addr};
- 
-  #[test]
-  fn test_tcp_parse() {
-    let parse_address = Address::new_tcp_address("127.0.0.1:443");
-    let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443);
-    assert_eq!(parse_address.unwrap(), Address::Tcp(socket_addr));
-  }
-
-  #[test]
-  fn test_vsock_parse() {
-    let address = Address::new_vsock_address("3:8008");
-    let vsock_addr = Address::Vsock(3, 8008);
-    assert_eq!(vsock_addr, address.unwrap());
-
-    let invalid_address = Address::new_vsock_address("3.14:0000");
-    assert!(invalid_address.is_err());
-
-    let too_many_tokens = Address::new_vsock_address("3:8008:9999:0000");
-    assert!(too_many_tokens.is_err());
-  }
-}
-
-#[pin_project::pin_project(project = EnumProj)]
-enum Connection {
-  Tcp(#[pin] tokio::net::TcpStream),
-  Vsock(#[pin] tokio_vsock::VsockStream),
-}
-
-impl tokio::io::AsyncRead for Connection {
-    fn poll_read(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-      let this = self.project();
-      match this {
-        EnumProj::Tcp(conn) => {
-          conn.poll_read(cx, buf)
-        },
-        EnumProj::Vsock(conn) => {
-          conn.poll_read(cx, buf)
-        }
-      }
-    }
-}
-
-impl tokio::io::AsyncWrite for Connection {
-    fn poll_write(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> std::task::Poll<Result<usize, std::io::Error>> {
-      let this = self.project();
-      match this {
-        EnumProj::Tcp(conn) => {
-          conn.poll_write(cx, buf)
-        },
-        EnumProj::Vsock(conn) => {
-          conn.poll_write(cx, buf)
-        }
-      }
-    }
-
-    fn poll_flush(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), std::io::Error>> {
-      let this = self.project();
-      match this {
-        EnumProj::Tcp(conn) => {
-          conn.poll_flush(cx)
-        },
-        EnumProj::Vsock(conn) => {
-          conn.poll_flush(cx)
-        }
-      }
-    }
-
-    fn poll_shutdown(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), std::io::Error>> {
-      let this = self.project();
-      match this {
-        EnumProj::Tcp(conn) => {
-          conn.poll_shutdown(cx)
-        },
-        EnumProj::Vsock(conn) => {
-          conn.poll_shutdown(cx)
-        }
-      }
-    }
-}
-
-enum SourceConnection {
-  Tcp(tokio::net::TcpListener),
-  Vsock(tokio_vsock::VsockListener),
-}
-
-#[async_trait::async_trait]
-impl shared::server::Listener for SourceConnection {
-    type Connection = Connection;
-    type Error = tokio::io::Error;
-
-    async fn accept(&mut self) -> Result<Self::Connection,Self::Error> {
-      match self {
-        Self::Tcp(tcp_listener) => {
-          let (accepted_conn, _socket) = tcp_listener.accept().await?;
-          Ok(Connection::Tcp(accepted_conn))
-        },
-        Self::Vsock(vsock_listener) => {
-          let (vsock_conn, _socket) = vsock_listener.accept().await?;
-          Ok(Connection::Vsock(vsock_conn))
-        }
-      }
-    }
-}
 
 fn main() {
     let matches = Command::new("vsock-proxy")
@@ -286,26 +94,27 @@ fn main() {
         };
 
         loop {
-          let mut accepted_conn = match source.accept().await {
-            Ok(source_conn) => source_conn,
-            Err(e) => {
-              eprintln!("Failed to accept incoming connection - {e}");
-              continue;
+            let mut accepted_conn = match source.accept().await {
+                Ok(source_conn) => source_conn,
+                Err(e) => {
+                    eprintln!("Failed to accept incoming connection - {e}");
+                    continue;
+                }
+            };
+
+            let mut destination = match destination_address.into_destination_connection().await {
+                Ok(dest_conn) => dest_conn,
+                Err(e) => {
+                    eprintln!("Failed to create destination connection - {e}");
+                    continue;
+                }
+            };
+
+            if let Err(e) =
+                tokio::io::copy_bidirectional(&mut accepted_conn, &mut destination).await
+            {
+                eprintln!("Error piping connections - {e}");
             }
-          };
-
-          let mut destination = match destination_address.into_destination_connection().await {
-              Ok(dest_conn) => dest_conn,
-              Err(e) => {
-                  eprintln!("Failed to create destination connection - {e}");
-                  continue;
-              }
-          };
-
-          if let Err(e) = tokio::io::copy_bidirectional(&mut accepted_conn, &mut destination).await {
-              eprintln!("Error piping connections - {e}");
-          }
         }
-
     });
 }

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -1,0 +1,311 @@
+use clap::{Arg, Command};
+use shared::server::Listener;
+use std::{net::AddrParseError, num::ParseIntError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum VsockParseError {
+    #[error(
+        "Failed to parse vsock address. Incorrect number of tokens found. Expected 2, Received {0}"
+    )]
+    InvalidAddress(usize),
+    #[error("Failed to parse tokens in vsock address. Expected 2 numeric tokens separated by a colon (CID:PORT) e.g. 1234:8008")]
+    TokenParseError(#[from] ParseIntError),
+}
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("Failed to parse tcp socket address - {0}")]
+    TcpParseError(#[from] AddrParseError),
+    #[error(transparent)]
+    VsockParseError(#[from] VsockParseError),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Address {
+    Vsock(u32, u32),
+    Tcp(std::net::SocketAddr),
+}
+
+impl Address {
+    fn new_tcp_address(addr: &str) -> Result<Self, Error> {
+        let socket_addr = addr.parse()?;
+        Ok(Self::Tcp(socket_addr))
+    }
+
+    fn new_vsock_address(addr: &str) -> Result<Self, Error> {
+        let addr_parts: Vec<&str> = addr.split(':').collect();
+        if addr_parts.len() != 2 {
+            return Err(Error::VsockParseError(VsockParseError::InvalidAddress(
+                addr_parts.len(),
+            )));
+        }
+
+        let parsed_cid = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
+            Ok(cid) => cid,
+            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
+        };
+
+        let parsed_port = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
+            Ok(port) => port,
+            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
+        };
+
+        Ok(Self::Vsock(parsed_cid, parsed_port))
+    }
+
+    async fn into_listener(self) -> Result<SourceConnection, tokio::io::Error> {
+      match self {
+        Self::Tcp(tcp_addr) => {
+          let listener = tokio::net::TcpListener::bind(tcp_addr).await?;
+          Ok(SourceConnection::Tcp(listener))
+        },
+        Self::Vsock(cid, port) => {
+          let listener = tokio_vsock::VsockListener::bind(cid, port)?;
+          Ok(SourceConnection::Vsock(listener))
+        }
+      }
+    }
+
+    async fn into_destination_connection(&self) -> Result<Connection, tokio::io::Error> {
+      match self {
+        Self::Tcp(tcp_addr) => {
+          let socket = tokio::net::TcpStream::connect(tcp_addr).await?;
+          Ok(Connection::Tcp(socket))
+        },
+        Self::Vsock(cid, port) => {
+          let socket = tokio_vsock::VsockStream::connect(*cid, *port).await?;
+          Ok(Connection::Vsock(socket))
+        }
+      }
+    }
+}
+
+#[cfg(test)] 
+mod test {
+  use super::Address;
+  use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+ 
+  #[test]
+  fn test_tcp_parse() {
+    let parse_address = Address::new_tcp_address("127.0.0.1:443");
+    let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443);
+    assert_eq!(parse_address.unwrap(), Address::Tcp(socket_addr));
+  }
+
+  #[test]
+  fn test_vsock_parse() {
+    let address = Address::new_vsock_address("3:8008");
+    let vsock_addr = Address::Vsock(3, 8008);
+    assert_eq!(vsock_addr, address.unwrap());
+
+    let invalid_address = Address::new_vsock_address("3.14:0000");
+    assert!(invalid_address.is_err());
+
+    let too_many_tokens = Address::new_vsock_address("3:8008:9999:0000");
+    assert!(too_many_tokens.is_err());
+  }
+}
+
+#[pin_project::pin_project(project = EnumProj)]
+enum Connection {
+  Tcp(#[pin] tokio::net::TcpStream),
+  Vsock(#[pin] tokio_vsock::VsockStream),
+}
+
+impl tokio::io::AsyncRead for Connection {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+      let this = self.project();
+      match this {
+        EnumProj::Tcp(conn) => {
+          conn.poll_read(cx, buf)
+        },
+        EnumProj::Vsock(conn) => {
+          conn.poll_read(cx, buf)
+        }
+      }
+    }
+}
+
+impl tokio::io::AsyncWrite for Connection {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+      let this = self.project();
+      match this {
+        EnumProj::Tcp(conn) => {
+          conn.poll_write(cx, buf)
+        },
+        EnumProj::Vsock(conn) => {
+          conn.poll_write(cx, buf)
+        }
+      }
+    }
+
+    fn poll_flush(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), std::io::Error>> {
+      let this = self.project();
+      match this {
+        EnumProj::Tcp(conn) => {
+          conn.poll_flush(cx)
+        },
+        EnumProj::Vsock(conn) => {
+          conn.poll_flush(cx)
+        }
+      }
+    }
+
+    fn poll_shutdown(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), std::io::Error>> {
+      let this = self.project();
+      match this {
+        EnumProj::Tcp(conn) => {
+          conn.poll_shutdown(cx)
+        },
+        EnumProj::Vsock(conn) => {
+          conn.poll_shutdown(cx)
+        }
+      }
+    }
+}
+
+enum SourceConnection {
+  Tcp(tokio::net::TcpListener),
+  Vsock(tokio_vsock::VsockListener),
+}
+
+#[async_trait::async_trait]
+impl shared::server::Listener for SourceConnection {
+    type Connection = Connection;
+    type Error = tokio::io::Error;
+
+    async fn accept(&mut self) -> Result<Self::Connection,Self::Error> {
+      match self {
+        Self::Tcp(tcp_listener) => {
+          let (accepted_conn, _socket) = tcp_listener.accept().await?;
+          Ok(Connection::Tcp(accepted_conn))
+        },
+        Self::Vsock(vsock_listener) => {
+          let (vsock_conn, _socket) = vsock_listener.accept().await?;
+          Ok(Connection::Vsock(vsock_conn))
+        }
+      }
+    }
+}
+
+fn main() {
+    let matches = Command::new("vsock-proxy")
+        .about("A simple proxy to pipe traffic to/from a vsock connection")
+        .arg(
+            Arg::new("tcp-source")
+                .long("tcp-source")
+                .help("The tcp source address for the proxy to bind to.")
+                .conflicts_with("vsock-source")
+                .required(false),
+        )
+        .arg(
+            Arg::new("tcp-destination")
+                .long("tcp-dest")
+                .help("The tcp destination address for the proxy to forward to.")
+                .conflicts_with("vsock-destination")
+                .conflicts_with("tcp-source")
+                .required(false),
+        )
+        .arg(
+            Arg::new("vsock-source")
+                .long("vsock-source")
+                .help("The vsock source address for the proxy to bind to.")
+                .required(false),
+        )
+        .arg(
+            Arg::new("vsock-destination")
+                .long("vsock-dest")
+                .help("The vsock destination address for the proxy to forward to.")
+                .conflicts_with("vsock-source")
+                .required(false),
+        )
+        .get_matches();
+
+    let tcp_source = matches.get_one::<String>("tcp-source");
+    let vsock_source = matches.get_one::<String>("vsock-source");
+
+    if tcp_source.is_none() && vsock_source.is_none() {
+        eprintln!("Error: no source address provided. Either tcp-source or vsock-source must be provided.");
+        return;
+    }
+
+    let tcp_destination = matches.get_one::<String>("tcp-destination");
+    let vsock_destination = matches.get_one::<String>("vsock-destination");
+
+    if tcp_destination.is_none() && vsock_destination.is_none() {
+        eprintln!("Error: no destination address provided. Either tcp-destination or vsock-destination must be provided.");
+        return;
+    }
+
+    let parsed_source_address: Result<Address, Error> = tcp_source
+        .map(|tcp_addr| Address::new_tcp_address(tcp_addr.as_str()))
+        .or_else(|| vsock_source.map(|vsock_addr| Address::new_vsock_address(vsock_addr.as_str())))
+        .expect("Infallible: either tcp or vsock source address must exist.");
+
+    let source_address = match parsed_source_address {
+        Ok(source_addr) => source_addr,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return;
+        }
+    };
+
+    let parsed_destination: Result<Address, Error> = tcp_destination
+        .map(|tcp_addr| Address::new_tcp_address(tcp_addr))
+        .or_else(|| vsock_source.map(|vsock_addr| Address::new_vsock_address(vsock_addr)))
+        .expect("Infallible: either tcp or vsock address must exist");
+
+    let destination_address = match parsed_destination {
+        Ok(dest_addr) => dest_addr,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return;
+        }
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    runtime.block_on(async move {
+        let mut source = match source_address.into_listener().await {
+            Ok(source_conn) => source_conn,
+            Err(e) => {
+                eprintln!("Failed to create source connection - {e}");
+                return;
+            }
+        };
+
+        loop {
+          let mut accepted_conn = match source.accept().await {
+            Ok(source_conn) => source_conn,
+            Err(e) => {
+              eprintln!("Failed to accept incoming connection - {e}");
+              continue;
+            }
+          };
+
+          let mut destination = match destination_address.into_destination_connection().await {
+              Ok(dest_conn) => dest_conn,
+              Err(e) => {
+                  eprintln!("Failed to create destination connection - {e}");
+                  continue;
+              }
+          };
+
+          if let Err(e) = tokio::io::copy_bidirectional(&mut accepted_conn, &mut destination).await {
+              eprintln!("Error piping connections - {e}");
+          }
+        }
+
+    });
+}

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -46,7 +46,7 @@ impl Address {
             Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
         };
 
-        let parsed_port = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
+        let parsed_port = match addr_parts.get(1).unwrap().trim().parse::<u32>() {
             Ok(port) => port,
             Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
         };

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -203,14 +203,14 @@ fn main() {
         .arg(
             Arg::new("tcp-source")
                 .long("tcp-source")
-                .help("The tcp source address for the proxy to bind to.")
+                .help("The tcp address for the proxy to listen on.")
                 .conflicts_with("vsock-source")
                 .required(false),
         )
         .arg(
             Arg::new("tcp-destination")
                 .long("tcp-dest")
-                .help("The tcp destination address for the proxy to forward to.")
+                .help("The tcp address for the proxy to forward to.")
                 .conflicts_with("vsock-destination")
                 .conflicts_with("tcp-source")
                 .required(false),
@@ -218,13 +218,13 @@ fn main() {
         .arg(
             Arg::new("vsock-source")
                 .long("vsock-source")
-                .help("The vsock source address for the proxy to bind to.")
+                .help("The vsock address for the proxy to listen on.")
                 .required(false),
         )
         .arg(
             Arg::new("vsock-destination")
                 .long("vsock-dest")
-                .help("The vsock destination address for the proxy to forward to.")
+                .help("The vsock address for the proxy to forward to.")
                 .conflicts_with("vsock-source")
                 .required(false),
         )

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
                 }
             };
 
-            let mut destination = match destination_address.into_destination_connection().await {
+            let mut destination = match destination_address.get_destination_connection().await {
                 Ok(dest_conn) => dest_conn,
                 Err(e) => {
                     eprintln!("Failed to create destination connection - {e}");

--- a/crates/vsock-proxy/src/net.rs
+++ b/crates/vsock-proxy/src/net.rs
@@ -1,4 +1,3 @@
-use shared::server::Listener;
 use std::{net::AddrParseError, num::ParseIntError};
 use thiserror::Error;
 
@@ -40,6 +39,7 @@ impl Address {
             )));
         }
 
+        #[allow(clippy::get_first)]
         let parsed_cid = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
             Ok(cid) => cid,
             Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
@@ -68,7 +68,7 @@ impl Address {
     }
 
     /// Convert an address into a destination connection to forward traffic over
-    pub async fn into_destination_connection(&self) -> Result<Connection, tokio::io::Error> {
+    pub async fn get_destination_connection(&self) -> Result<Connection, tokio::io::Error> {
         match self {
             Self::Tcp(tcp_addr) => {
                 let socket = tokio::net::TcpStream::connect(tcp_addr).await?;

--- a/crates/vsock-proxy/src/net.rs
+++ b/crates/vsock-proxy/src/net.rs
@@ -1,0 +1,190 @@
+use shared::server::Listener;
+use std::{net::AddrParseError, num::ParseIntError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VsockParseError {
+    #[error(
+        "Failed to parse vsock address. Incorrect number of tokens found. Expected 2, Received {0}"
+    )]
+    InvalidAddress(usize),
+    #[error("Failed to parse tokens in vsock address. Expected 2 numeric tokens separated by a colon (CID:PORT) e.g. 1234:8008")]
+    TokenParseError(#[from] ParseIntError),
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Failed to parse tcp socket address - {0}")]
+    TcpParseError(#[from] AddrParseError),
+    #[error(transparent)]
+    VsockParseError(#[from] VsockParseError),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Address {
+    Vsock(u32, u32),
+    Tcp(std::net::SocketAddr),
+}
+
+impl Address {
+    pub fn new_tcp_address(addr: &str) -> Result<Self, Error> {
+        let socket_addr = addr.parse()?;
+        Ok(Self::Tcp(socket_addr))
+    }
+
+    pub fn new_vsock_address(addr: &str) -> Result<Self, Error> {
+        let addr_parts: Vec<&str> = addr.split(':').collect();
+        if addr_parts.len() != 2 {
+            return Err(Error::VsockParseError(VsockParseError::InvalidAddress(
+                addr_parts.len(),
+            )));
+        }
+
+        let parsed_cid = match addr_parts.get(0).unwrap().trim().parse::<u32>() {
+            Ok(cid) => cid,
+            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
+        };
+
+        let parsed_port = match addr_parts.get(1).unwrap().trim().parse::<u32>() {
+            Ok(port) => port,
+            Err(e) => return Err(Error::VsockParseError(VsockParseError::from(e))),
+        };
+
+        Ok(Self::Vsock(parsed_cid, parsed_port))
+    }
+
+    /// Convert an address into a listener capable of accepting incoming connections to proxy to the destination
+    pub async fn into_listener(self) -> Result<SourceConnection, tokio::io::Error> {
+        match self {
+            Self::Tcp(tcp_addr) => {
+                let listener = tokio::net::TcpListener::bind(tcp_addr).await?;
+                Ok(SourceConnection::Tcp(listener))
+            }
+            Self::Vsock(cid, port) => {
+                let listener = tokio_vsock::VsockListener::bind(cid, port)?;
+                Ok(SourceConnection::Vsock(listener))
+            }
+        }
+    }
+
+    /// Convert an address into a destination connection to forward traffic over
+    pub async fn into_destination_connection(&self) -> Result<Connection, tokio::io::Error> {
+        match self {
+            Self::Tcp(tcp_addr) => {
+                let socket = tokio::net::TcpStream::connect(tcp_addr).await?;
+                Ok(Connection::Tcp(socket))
+            }
+            Self::Vsock(cid, port) => {
+                let socket = tokio_vsock::VsockStream::connect(*cid, *port).await?;
+                Ok(Connection::Vsock(socket))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Address;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn test_tcp_parse() {
+        let parse_address = Address::new_tcp_address("127.0.0.1:443");
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443);
+        assert_eq!(parse_address.unwrap(), Address::Tcp(socket_addr));
+    }
+
+    #[test]
+    fn test_vsock_parse() {
+        let address = Address::new_vsock_address("3:8008");
+        let vsock_addr = Address::Vsock(3, 8008);
+        assert_eq!(vsock_addr, address.unwrap());
+
+        let invalid_address = Address::new_vsock_address("3.14:0000");
+        assert!(invalid_address.is_err());
+
+        let too_many_tokens = Address::new_vsock_address("3:8008:9999:0000");
+        assert!(too_many_tokens.is_err());
+    }
+}
+
+#[pin_project::pin_project(project = EnumProj)]
+/// Wrapper type to support both VSock and TCP as a generic connection type
+pub enum Connection {
+    Tcp(#[pin] tokio::net::TcpStream),
+    Vsock(#[pin] tokio_vsock::VsockStream),
+}
+
+impl tokio::io::AsyncRead for Connection {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.project();
+        match this {
+            EnumProj::Tcp(conn) => conn.poll_read(cx, buf),
+            EnumProj::Vsock(conn) => conn.poll_read(cx, buf),
+        }
+    }
+}
+
+impl tokio::io::AsyncWrite for Connection {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        let this = self.project();
+        match this {
+            EnumProj::Tcp(conn) => conn.poll_write(cx, buf),
+            EnumProj::Vsock(conn) => conn.poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.project();
+        match this {
+            EnumProj::Tcp(conn) => conn.poll_flush(cx),
+            EnumProj::Vsock(conn) => conn.poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.project();
+        match this {
+            EnumProj::Tcp(conn) => conn.poll_shutdown(cx),
+            EnumProj::Vsock(conn) => conn.poll_shutdown(cx),
+        }
+    }
+}
+
+pub enum SourceConnection {
+    Tcp(tokio::net::TcpListener),
+    Vsock(tokio_vsock::VsockListener),
+}
+
+#[async_trait::async_trait]
+impl shared::server::Listener for SourceConnection {
+    type Connection = Connection;
+    type Error = tokio::io::Error;
+
+    async fn accept(&mut self) -> Result<Self::Connection, Self::Error> {
+        match self {
+            Self::Tcp(tcp_listener) => {
+                let (accepted_conn, _socket) = tcp_listener.accept().await?;
+                Ok(Connection::Tcp(accepted_conn))
+            }
+            Self::Vsock(vsock_listener) => {
+                let (vsock_conn, _socket) = vsock_listener.accept().await?;
+                Ok(Connection::Vsock(vsock_conn))
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Why
When testing Cages, it's useful to be able to spin up a simple proxy on the host EC2 instance. The brave nitro-shim of [gvproxy](https://github.com/brave-intl/bat-go/tree/master/nitro-shim/tools/gvproxy) and aws [vsock-proxy](https://github.com/aws/aws-nitro-enclaves-cli/blob/main/vsock_proxy/README.md) address this issue but are only concerned with tunnelling traffic out of the enclave.

The `vsock-proxy` crate makes no assumptions about whether TCP or Vsock should be treated as the server vs client. A proxy can be run to tunnel traffic from the host into the enclave using:
```sh
vsock-proxy --tcp-source 127.0.0.1:8008 --vsock-dest 1234:5678
```

Similarly a client can be run from the enclave to the host using:
```sh
vsock-proxy --vsock-source 3:6789 --tcp-dest 127.0.0.1:5000
```

# How

- Add a small utility crate to support proxying to/from vsock. 
- Add CI which builds and tests the crate, and publishes it to crates.io on release