### PR TITLE
Chore: Update cages release trigger to avoid conflict from vsock-proxy releases

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 name: Deploy new control plane image to production
 env:

--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -3,7 +3,7 @@ name: Release data-plane binary production
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
# Why
Cages release workflows were triggered by tags pushed that matched `v*`. As a result, the new vsock-proxy crate's release flow will incorrectly trigger the Cage's release.

# How
Update the tag pattern to assert that it is a semver-like string prefixed by `v`
