### PR TITLE
Correct vsock-proxy release workflow

### DIFF
--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -10,7 +10,7 @@ name: vsock-proxy
 jobs:
   check-proxy:
     runs-on: ubuntu-latest
-    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
+    if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -31,7 +31,7 @@ jobs:
   test-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy]
-    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
+    if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -46,7 +46,7 @@ jobs:
   build-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy,test-proxy]
-    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') || github.event_name == 'push' }}
+    if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -63,7 +63,7 @@ jobs:
   release-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy, test-proxy, build-proxy]
-    if: ${{ startswith(github.event.release.tag_name, 'refs/tags/vsock-proxy') }}
+    if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
# Why
Startswith wouldn't match for vsock-proxy releases

# How
Use contains in place of startswith
