### PR TITLE
vsock-proxy: Remove dependency on local shared lib

### DIFF
--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') || github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -46,7 +46,7 @@ jobs:
   build-proxy:
     runs-on: ubuntu-latest
     needs: [check-proxy,test-proxy]
-    if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') || github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -62,7 +62,7 @@ jobs:
 
   release-proxy:
     runs-on: ubuntu-latest
-    needs: [check-proxy, test-proxy, build-proxy]
+    needs: [check-proxy,test-proxy]
     if: ${{ contains(github.event.release.tag_name, 'vsock-proxy') }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,6 @@ dependencies = [
  "async-trait",
  "clap",
  "pin-project",
- "shared",
  "thiserror",
  "tokio",
  "tokio-vsock",

--- a/crates/vsock-proxy/Cargo.toml
+++ b/crates/vsock-proxy/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 async-trait = "0.1.73"
 clap = "4.4.6"
 pin-project = "1.1.3"
-shared = { path = "../../shared" }
 thiserror = "1.0.30"
 tokio = { version = "1.12.0", features = ["net", "rt", "io-util"] }
 tokio-vsock = "0.3.2"

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -2,8 +2,7 @@ use clap::{Arg, Command};
 
 mod net;
 
-use net::{Address, Error};
-use shared::server::Listener;
+use net::{Address, Error, Listener};
 
 fn main() {
     let matches = Command::new("vsock-proxy")

--- a/crates/vsock-proxy/src/net.rs
+++ b/crates/vsock-proxy/src/net.rs
@@ -171,7 +171,14 @@ pub enum SourceConnection {
 }
 
 #[async_trait::async_trait]
-impl shared::server::Listener for SourceConnection {
+pub trait Listener: Sized {
+    type Connection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + Unpin;
+    type Error: std::fmt::Debug + std::fmt::Display;
+    async fn accept(&mut self) -> Result<Self::Connection, Self::Error>;
+}
+
+#[async_trait::async_trait]
+impl Listener for SourceConnection {
     type Connection = Connection;
     type Error = tokio::io::Error;
 


### PR DESCRIPTION
# Why
vsock-proxy's dependency on a local, unpublished lib blocks the publish step

# How
- Remove dependency on local shared lib
- Patch vsock-proxy workflow