### PR TITLE
vsock-proxy: add missing metadata fields to cargo.toml

### DIFF
--- a/crates/vsock-proxy/Cargo.toml
+++ b/crates/vsock-proxy/Cargo.toml
@@ -2,6 +2,10 @@
 name = "vsock-proxy"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "A minimal CLI to proxy TCP traffic to or from VSock"
+authors = ["Evervault Engineering <engineering@evervault.com>"]
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Why
Required fields before publishing

# How
Add missing fields - license, description, authors, readme.
