### PR TITLE
Fix destination parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "vsock-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "clap",

--- a/crates/vsock-proxy/Cargo.toml
+++ b/crates/vsock-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vsock-proxy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "A minimal CLI to proxy TCP traffic to or from VSock"

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
 
     let parsed_destination: Result<Address, Error> = tcp_destination
         .map(|tcp_addr| Address::new_tcp_address(tcp_addr))
-        .or_else(|| vsock_source.map(|vsock_addr| Address::new_vsock_address(vsock_addr)))
+        .or_else(|| vsock_destination.map(|vsock_addr| Address::new_vsock_address(vsock_addr)))
         .expect("Infallible: either tcp or vsock address must exist");
 
     let destination_address = match parsed_destination {


### PR DESCRIPTION
# Why
A typo in the destination parsing caused a panic when proxying to a vsock destination

# How
Correct destination parsing to handle vsock correctly
