### PR TITLE
vsock-proxy: fix runtime config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "vsock-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/crates/vsock-proxy/Cargo.toml
+++ b/crates/vsock-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vsock-proxy"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "A minimal CLI to proxy TCP traffic to or from VSock"

--- a/crates/vsock-proxy/src/main.rs
+++ b/crates/vsock-proxy/src/main.rs
@@ -80,6 +80,7 @@ fn main() {
     };
 
     let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
         .build()
         .expect("Failed to build tokio runtime");
 


### PR DESCRIPTION
# Why
Runtime panics on start as it requires IO

# How
Add IO to tokio runtime
