### PR TITLE
fix: update tcp forwarding server in data plane to spawn child tasks for incoming connections

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build Cages Project
         uses: evervault/cargo-static-build@master
         with:
-          cmd: cargo build --features network_egress --release --target x86_64-unknown-linux-musl
+          cmd: cargo build --features network_egress --release --target x86_64-unknown-linux-musl --exclude vsock-proxy
       - name: Build mock crypto API
         uses: evervault/cargo-static-build@master
         with:
@@ -40,7 +40,7 @@ jobs:
       - name: Build Cages Project
         uses: evervault/cargo-static-build@master
         with:
-          cmd: cargo build --release --target x86_64-unknown-linux-musl --features not_enclave --no-default-features
+          cmd: cargo build --release --target x86_64-unknown-linux-musl --features not_enclave --no-default-features --exclude vsock-proxy
       - name: Build mock crypto API
         uses: evervault/cargo-static-build@master
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build Cages Project
         uses: evervault/cargo-static-build@master
         with:
-          cmd: cargo build --features network_egress --release --target x86_64-unknown-linux-musl --exclude vsock-proxy
+          cmd: cargo build --features network_egress --release --target x86_64-unknown-linux-musl --workspace --exclude vsock-proxy
       - name: Build mock crypto API
         uses: evervault/cargo-static-build@master
         with:
@@ -40,7 +40,7 @@ jobs:
       - name: Build Cages Project
         uses: evervault/cargo-static-build@master
         with:
-          cmd: cargo build --release --target x86_64-unknown-linux-musl --features not_enclave --no-default-features --exclude vsock-proxy
+          cmd: cargo build --release --target x86_64-unknown-linux-musl --features not_enclave --no-default-features --workspace --exclude vsock-proxy
       - name: Build mock crypto API
         uses: evervault/cargo-static-build@master
         with:

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -26,7 +26,7 @@ jobs:
           args: -p vsock-proxy
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check formatting
-        run: cargo fmt --check
+        run: cargo fmt -p vsock-proxy --check
 
   test-proxy:
     runs-on: ubuntu-latest

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -167,32 +167,34 @@ where
             }
         };
 
-        let mut customer_stream = match tokio::net::TcpStream::connect(("0.0.0.0", port)).await {
-            Ok(customer_stream) => customer_stream,
-            Err(e) => {
-                log::error!(
-                    "An error occurred while connecting to the customer process — {}",
-                    e
-                );
-                continue;
-            }
-        };
-
-        if incoming_conn.has_proxy_protocol() && should_forward_proxy_protocol {
-            // flush proxy protocol bytes to customer process
-            let proxy_protocol = incoming_conn.proxy_protocol().unwrap();
-            if let Err(e) = customer_stream.write_all(proxy_protocol.as_bytes()).await {
-                log::error!(
-                    "An error occurred while forwarding the proxy protocol to the customer process — {}",
-                    e
-                );
-                continue;
-            }
-        }
-
-        if let Err(e) = pipe_streams(incoming_conn, customer_stream).await {
-            log::error!("An error occurred piping between the incoming connection and the customer process — {}", e);
-            continue;
-        }
+        tokio::spawn(async move {
+          let mut customer_stream = match tokio::net::TcpStream::connect(("0.0.0.0", port)).await {
+              Ok(customer_stream) => customer_stream,
+              Err(e) => {
+                  log::error!(
+                      "An error occurred while connecting to the customer process — {}",
+                      e
+                  );
+                  return;
+              }
+          };
+  
+          if incoming_conn.has_proxy_protocol() && should_forward_proxy_protocol {
+              // flush proxy protocol bytes to customer process
+              let proxy_protocol = incoming_conn.proxy_protocol().unwrap();
+              if let Err(e) = customer_stream.write_all(proxy_protocol.as_bytes()).await {
+                  log::error!(
+                      "An error occurred while forwarding the proxy protocol to the customer process — {}",
+                      e
+                  );
+                  return;
+              }
+          }
+  
+          if let Err(e) = pipe_streams(incoming_conn, customer_stream).await {
+              log::error!("An error occurred piping between the incoming connection and the customer process — {}", e);
+              return;
+          }
+        });
     }
 }


### PR DESCRIPTION
# Why
TCP Forwarding server within the data plane was not spawning child tasks for incoming connections which significantly reduced throughput.

# How
Correct server by spawning new tokio tasks per connection
