### PR TITLE
chore: bump remaining instances of tokio-rustls, use 0 dep version of webpki-roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
  "hyper-rustls",
  "lazy_static",
  "pin-project-lite",
- "rustls 0.21.7",
+ "rustls",
  "tokio",
  "tower",
  "tracing",
@@ -843,7 +843,7 @@ dependencies = [
  "thiserror",
  "tls-parser",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-test",
  "tokio-vsock",
  "trust-dns-resolver",
@@ -1076,7 +1076,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-test",
  "tokio-util 0.6.10",
  "tokio-vsock",
@@ -1530,10 +1530,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.7",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2346,18 +2346,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
@@ -2610,7 +2598,7 @@ dependencies = [
  "thiserror",
  "tls-parser",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-test",
  "tokio-vsock",
 ]
@@ -2862,22 +2850,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls",
  "tokio",
 ]
 
@@ -3258,23 +3235,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "widestring"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -29,7 +29,7 @@ serde_bytes = "0.11.6"
 serde_json = "1.0.83"
 sha2 = "0.10.2"
 rand = { version = "0.8.5" }
-webpki-roots = "0.22.4"
+webpki-roots = "0.25.2"
 pem = "1.1.0"
 base64 = "0.13.0"
 once_cell = "1.17.0"

--- a/data-plane/src/acme/client.rs
+++ b/data-plane/src/acme/client.rs
@@ -36,7 +36,7 @@ impl AcmeClient {
     pub fn new(server_name: ServerName) -> Self {
         let mut root_cert_store = RootCertStore::empty();
 
-        root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,

--- a/data-plane/src/base_tls_client/tls_client_config.rs
+++ b/data-plane/src/base_tls_client/tls_client_config.rs
@@ -6,7 +6,7 @@ use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor};
 pub fn get_tls_client_config(verifier: Arc<dyn ServerCertVerifier>) -> ClientConfig {
     let config_builder = tokio_rustls::rustls::ClientConfig::builder().with_safe_defaults();
     let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
-    root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4.23"
 rand = "^0.8"
 tls-parser = { version = "0.11.0", optional = true }
 ppp = { version = "2.2.0" }
-tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration"] }
+tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 sys-info = "0.9.1"
 cadence = "0.29.0"
 httparse = "1.8.0"


### PR DESCRIPTION
# Why
webpki-roots has been migrated away from a dependency on webpki (and in turn ring + untrusted). 

# How
- Update webpki-roots to latest to remove unneeded deps
- Update shared lib's tokio-rustls dependency to latest