### PR TITLE
[SPE-889] Order trusted cert asynchronously

### DIFF
--- a/data-plane/src/cache.rs
+++ b/data-plane/src/cache.rs
@@ -21,6 +21,12 @@ pub struct TrustedCertStore {
     cage_initliazed_time: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+impl Default for TrustedCertStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TrustedCertStore {
     pub fn new() -> Self {
         Self {
@@ -38,7 +44,7 @@ impl TrustedCertStore {
     }
 
     pub fn get_initialized_time(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        self.cage_initliazed_time.clone()
+        self.cage_initliazed_time
     }
 
     pub fn set_initialized_time(&mut self, time: chrono::DateTime<chrono::Utc>) {

--- a/data-plane/src/cache.rs
+++ b/data-plane/src/cache.rs
@@ -1,6 +1,9 @@
+use std::sync::RwLock;
+
 use cached::TimedSizedCache;
 use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
+use tokio_rustls::rustls::sign::CertifiedKey;
 
 use crate::crypto::token::AttestationAuth;
 
@@ -12,3 +15,36 @@ pub static E3_TOKEN: Lazy<Mutex<TimedSizedCache<String, AttestationAuth>>> = Laz
         E3_TOKEN_LIFETIME,
     ))
 });
+
+pub struct TrustedCertStore {
+    trusted_cert: Option<CertifiedKey>,
+    cage_initliazed_time: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl TrustedCertStore {
+    pub fn new() -> Self {
+        Self {
+            trusted_cert: None,
+            cage_initliazed_time: None,
+        }
+    }
+
+    pub fn get_trusted_cert(&self) -> Option<CertifiedKey> {
+        self.trusted_cert.clone()
+    }
+
+    pub fn set_trusted_cert(&mut self, trusted_cert: CertifiedKey) {
+        self.trusted_cert = Some(trusted_cert);
+    }
+
+    pub fn get_initialized_time(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.cage_initliazed_time.clone()
+    }
+
+    pub fn set_initialized_time(&mut self, time: chrono::DateTime<chrono::Utc>) {
+        self.cage_initliazed_time = Some(time);
+    }
+}
+
+pub static TRUSTED_CERT_STORE: Lazy<RwLock<TrustedCertStore>> =
+    Lazy::new(|| RwLock::new(TrustedCertStore::new()));

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -319,7 +319,7 @@ impl AttestableCertResolver {
             match TRUSTED_CERT_STORE.read() {
                 Ok(trusted_cert_store) => trusted_cert_store
                     .get_trusted_cert()
-                    .map(|cert| Arc::new(cert)),
+                    .map(Arc::new),
                 Err(_) => {
                     log::error!("Unable to get lock on the for publicly trusted certificate.");
                     None

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -317,9 +317,7 @@ impl AttestableCertResolver {
             Some(certified_key)
         } else if Self::is_trusted_cert_domain(server_name) {
             match TRUSTED_CERT_STORE.read() {
-                Ok(trusted_cert_store) => trusted_cert_store
-                    .get_trusted_cert()
-                    .map(Arc::new),
+                Ok(trusted_cert_store) => trusted_cert_store.get_trusted_cert().map(Arc::new),
                 Err(_) => {
                     log::error!("Unable to get lock on the for publicly trusted certificate.");
                     None

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -368,7 +368,7 @@ mod tests {
         };
     }
 
-    fn get_test_trusted_cert() -> Option<CertifiedKey>{
+    fn get_test_trusted_cert() -> Option<CertifiedKey> {
         TRUSTED_CERT_STORE.read().unwrap().get_trusted_cert()
     }
 

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -120,7 +120,14 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
         });
 
         #[cfg(not(feature = "enclave"))] // Don't order trusted certs locally
-        log::info!("Not ordering trusted cert, running in non-enclave mode");
+        {
+            log::info!("Not ordering trusted cert, running in non-enclave mode");
+
+            //Once trusted cert ordered and stored, write trusted cert initialised var
+            if let Err(err) = Environment::write_trusted_cert_complete_env_var() {
+                log::error!("Error writing trusted cert initialised env var: {err}");
+            }
+        }
     }
 
     async fn get_ca_with_retry() -> (X509, PKey<Private>) {

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tokio_rustls::rustls::server::WantsServerCert;
+#[cfg(feature = "enclave")]
 use tokio_rustls::rustls::sign::CertifiedKey;
 use tokio_rustls::rustls::ConfigBuilder;
 use tokio_rustls::rustls::ServerConfig;
@@ -22,6 +23,8 @@ use super::inter_ca_retreiver;
 #[cfg(feature = "enclave")]
 use crate::acme;
 
+#[cfg(feature = "enclave")]
+use crate::cache::TRUSTED_CERT_STORE;
 use crate::env::Environment;
 use crate::server::error::ServerResult;
 use crate::server::error::TlsError;
@@ -79,27 +82,45 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
     }
 
     pub async fn with_attestable_cert(self) -> ServerResult<TlsServer<S>> {
+        Self::start_trusted_cert_background_order();
+
         log::info!("Creating TLSServer with attestable cert");
         let (ca_cert, ca_private_key) = Self::get_ca_with_retry().await;
         log::debug!("Received intermediate CA from cert provisioner. Using it with TLS Server.");
 
-        #[cfg(feature = "enclave")]
-        let trusted_cert: Option<CertifiedKey> = enclave_trusted_cert().await;
-
-        #[cfg(not(feature = "enclave"))] // Don't order trusted certs locally
-        let trusted_cert: Option<CertifiedKey> = None;
-
         //Once intermediate cert and trusted cert retrieved, write cage initialised vars
         Environment::write_startup_complete_env_vars()?;
 
-        let attestable_cert_resolver = super::cert_resolver::AttestableCertResolver::new(
-            ca_cert,
-            ca_private_key,
-            trusted_cert,
-        )?;
+        let attestable_cert_resolver =
+            super::cert_resolver::AttestableCertResolver::new(ca_cert, ca_private_key)?;
         let tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));
         Ok(TlsServer::new(tls_config, self.tcp_server))
+    }
+
+    fn start_trusted_cert_background_order() {
+        #[cfg(feature = "enclave")]
+        tokio::spawn(async move {
+            let trusted_cert: Option<CertifiedKey> = enclave_trusted_cert().await;
+            match TRUSTED_CERT_STORE.write() {
+                Ok(mut store) => {
+                    if let Some(trusted_cert) = trusted_cert {
+                        store.set_trusted_cert(trusted_cert);
+                    }
+
+                    //Once trusted cert ordered and stored, write trusted cert initialised var
+                    if let Err(err) = Environment::write_trusted_cert_complete_env_var() {
+                        log::error!("Error writing trusted cert initialised env var: {err}");
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error writing trusted cert to store: {e}");
+                }
+            }
+        });
+
+        #[cfg(not(feature = "enclave"))] // Don't order trusted certs locally
+        log::info!("Not ordering trusted cert, running in non-enclave mode");
     }
 
     async fn get_ca_with_retry() -> (X509, PKey<Private>) {


### PR DESCRIPTION
# Why
Cert ordering can take some time which is causing some deployments to time out. We're moving to doing it async while first serving the untrusted cert and then serving the trusted one once it's ordered.

# How


Introduced a new ENV var to be written to the env file (`EV_CAGE_CERT_READY`). This is written when the trusted cert is ready. I also added a struct for storing the cert and initialisation time.

```
pub struct TrustedCertStore {
    trusted_cert: Option<CertifiedKey>,
    cage_initliazed_time: Option<chrono::DateTime<chrono::Utc>>,
}
```

The cage starts off with both set as none. When the cage has successfully started (while the trusted cert is still being ordered), the time is written to this struct. Healthchecks then check for the trusted cert ready var and if it's not there, checks if this time is longer than 3 minutes ago and if so fails the health check.

I put the certStore in a RwLock as it'll be read heavy (every health check) and only be written to twice in the whole process. (1. Cage init time, 2. Actual cert)