### PR TITLE
chore(ci): update trigger for workflows to account for lockfile

### DIFF
--- a/.github/workflows/test-control-plane.yml
+++ b/.github/workflows/test-control-plane.yml
@@ -4,6 +4,7 @@ on:
       - control-plane/**
       - shared/**
       - .github/workflows/test-control-plane.yml
+      - Cargo.lock
 name: Test Control Plane
 jobs:
   test_control_plane:

--- a/.github/workflows/test-data-plane.yml
+++ b/.github/workflows/test-data-plane.yml
@@ -4,6 +4,7 @@ on:
       - data-plane/**
       - shared/**
       - .github/workflows/test-data-plane.yml
+      - Cargo.lock
 name: Test Data Plane
 jobs:
   check_data_plane:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,6 +5,7 @@ on:
       - data-plane/**
       - control-plane/**
       - .github/workflows/test-e2e.yml
+      - Cargo.lock
 name: Run end-to-end tests
 jobs:
   run_e2e_tests_full_features:

--- a/.github/workflows/test-runtime-builder.yml
+++ b/.github/workflows/test-runtime-builder.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - installer/**
       - .github/workflows/test-runtime-builder.yml
+      - Cargo.lock
 name: Build runtime installer
 jobs:
   run-build-on-runtime-installer:

--- a/.github/workflows/test-shared-lib.yml
+++ b/.github/workflows/test-shared-lib.yml
@@ -3,6 +3,7 @@ on:
     paths:
       - shared/**
       - .github/workflows/test-shared-lib.yml
+      - Cargo.lock
 name: Test Shared Library
 jobs:
   test_shared_lib:

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -6,6 +6,7 @@ on:
       - crates/vsock-proxy/**
       - shared/**
       - .github/workflows/vsock-proxy.yml
+      - Cargo.lock
 name: vsock-proxy
 jobs:
   check-proxy:


### PR DESCRIPTION
# Why
Builds weren't being triggered in CI by changes in dependencies at the top level

# How
Add Cargo.lock to the paths lists.