### PR TITLE
Fix: Cert "not_after" failing to parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1369bc6b9e9a7dfdae2055f6ec151fe9c554a9d23d357c0237cee2e25eaabb7"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.2",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f5ebdc942f57ed96d560a6d1a459bae5851102a25d5bf89dc04ae453e31ecf"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1058,7 @@ dependencies = [
  "cadence",
  "cadence-macros",
  "chrono",
+ "chrono-tz",
  "dashmap 5.5.3",
  "dns-message-parser",
  "futures",
@@ -1998,6 +2021,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +2056,16 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -2033,8 +2074,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -2043,7 +2094,17 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
  "rand",
 ]
 
@@ -2052,6 +2113,15 @@ name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -2772,8 +2842,8 @@ dependencies = [
  "enum_primitive",
  "nom",
  "nom-derive",
- "phf",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "rusticata-macros",
 ]
 

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -44,6 +44,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 log = { version = "0.4.19", features = ["max_level_debug"] }
 rlimit = { version = "0.10.1", optional = true }
 hyper-rustls = { version = "0.24.1", default-features = false, features = ["http1","http2","tls12","tokio-runtime"] }
+chrono-tz = { version = "0.8.3" }
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/data-plane/src/crypto/attest.rs
+++ b/data-plane/src/crypto/attest.rs
@@ -1,9 +1,10 @@
 use crate::utils::nsm::{NsmConnection, NsmConnectionError};
 use aws_nitro_enclaves_cose as cose;
 use aws_nitro_enclaves_nsm_api as nitro;
-use chrono::DateTime;
+use chrono::{DateTime, NaiveDateTime, TimeZone};
 use openssl::x509::X509;
 use serde_bytes::ByteBuf;
+use std::str::FromStr;
 use std::fmt::Formatter;
 use std::time::{Duration, SystemTime};
 use thiserror::Error;
@@ -96,6 +97,9 @@ pub fn get_expiry_time(cose_sign_1_bytes: &[u8]) -> Result<SystemTime, Attestati
     let signing_cert = X509::from_der(&attestation_doc.certificate[..])
         .map_err(AttestationError::SigningCertParseFailed)?;
     let not_after = signing_cert.not_after().to_string();
-    let date_time = DateTime::parse_from_str(&not_after, "%b %e %H:%M:%S %Y %Z")?;
-    Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(date_time.timestamp() as u64))
+    let (date_time, remainder) = NaiveDateTime::parse_and_remainder(&not_after, "%b %e %H:%M:%S %Y")?;
+    let tz = chrono_tz::Tz::from_str(remainder).unwrap_or_else(|_| chrono_tz::UTC);
+    let offset = tz.offset_from_utf_date(&date_time);
+    let utc_date_time = DateTime::<chrono::Utc>::from_naive_utc_and_offset(date_time, offset);
+    Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(utc_date_time.timestamp() as u64))
 }

--- a/data-plane/src/crypto/attest.rs
+++ b/data-plane/src/crypto/attest.rs
@@ -103,12 +103,10 @@ pub fn get_expiry_time(cose_sign_1_bytes: &[u8]) -> Result<SystemTime, Attestati
     Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(utc_date_time.timestamp() as u64))
 }
 
-fn parse_not_after_date_time(
-    not_after: &str,
-) -> Result<DateTime<chrono_tz::Tz>, AttestationError> {
+fn parse_not_after_date_time(not_after: &str) -> Result<DateTime<chrono_tz::Tz>, AttestationError> {
     let (date_time, remainder) =
-        NaiveDateTime::parse_and_remainder(&not_after, "%b %e %H:%M:%S %Y")?;
-    let tz = chrono_tz::Tz::from_str(remainder).unwrap_or_else(|_| chrono_tz::UTC);
+        NaiveDateTime::parse_and_remainder(not_after, "%b %e %H:%M:%S %Y")?;
+    let tz = chrono_tz::Tz::from_str(remainder).unwrap_or(chrono_tz::UTC);
     date_time
         .and_local_timezone(tz)
         .earliest()
@@ -117,14 +115,14 @@ fn parse_not_after_date_time(
 
 #[cfg(test)]
 mod test {
-  use super::parse_not_after_date_time;
+    use super::parse_not_after_date_time;
 
-  #[test]
-  fn test_parse_valid_utc_date() {
-    let result = parse_not_after_date_time("Dec  6 23:59:59 2023 UTC");
-    assert!(result.is_ok());
-    let time = result.unwrap();
-    let serialized_time = time.to_rfc3339();
-    assert_eq!("2023-12-06T23:59:59+00:00", &serialized_time);
-  }
+    #[test]
+    fn test_parse_valid_utc_date() {
+        let result = parse_not_after_date_time("Dec  6 23:59:59 2023 UTC");
+        assert!(result.is_ok());
+        let time = result.unwrap();
+        let serialized_time = time.to_rfc3339();
+        assert_eq!("2023-12-06T23:59:59+00:00", &serialized_time);
+    }
 }

--- a/data-plane/src/crypto/attest.rs
+++ b/data-plane/src/crypto/attest.rs
@@ -106,7 +106,7 @@ pub fn get_expiry_time(cose_sign_1_bytes: &[u8]) -> Result<SystemTime, Attestati
 fn parse_not_after_date_time(not_after: &str) -> Result<DateTime<chrono_tz::Tz>, AttestationError> {
     let (date_time, remainder) =
         NaiveDateTime::parse_and_remainder(not_after, "%b %e %H:%M:%S %Y")?;
-    let tz = chrono_tz::Tz::from_str(remainder).unwrap_or(chrono_tz::UTC);
+    let tz = chrono_tz::Tz::from_str(remainder.trim()).unwrap_or(chrono_tz::UTC);
     date_time
         .and_local_timezone(tz)
         .earliest()

--- a/data-plane/src/crypto/attest.rs
+++ b/data-plane/src/crypto/attest.rs
@@ -114,3 +114,17 @@ fn parse_not_after_date_time(
         .earliest()
         .ok_or_else(|| AttestationError::InvalidTimeError(not_after.to_string()))
 }
+
+#[cfg(test)]
+mod test {
+  use super::parse_not_after_date_time;
+
+  #[test]
+  fn test_parse_valid_utc_date() {
+    let result = parse_not_after_date_time("Dec  6 23:59:59 2023 UTC");
+    assert!(result.is_ok());
+    let time = result.unwrap();
+    let serialized_time = time.to_rfc3339();
+    assert_eq!("2023-12-06T23:59:59+00:00", &serialized_time);
+  }
+}


### PR DESCRIPTION
# Why
Updating chrono to the latest version led to certificate not_after values failing to parse on startup. 

# How
- Update parsing to use both chrono and chrono_tz - chrono parses the time, and the timezone label is parsed by chrono_tz
- Add test for cert parsing
