### PR TITLE
fix: add missing semver variable to push step

### DIFF
--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -71,6 +71,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
+          SEMVER: ${{ steps.get_version.outputs.version }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$SEMVER
@@ -119,6 +120,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
+          SEMVER: ${{ steps.get_version.outputs.version }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$SEMVER


### PR DESCRIPTION
# Why
Tag being pushed was using the semver variable as a suffix but the variable wasn't declared for the final step resulting in an incorrect tag.

# How
Add semver variable to the final push step for the control plane.
