### PR TITLE
Publish to new version schema on deployment

### DIFF
--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -101,7 +101,9 @@ jobs:
         run: |
           echo "{ \"data-plane\": \"${{ env.VERSION_TAG }}\" }" > latest.txt
           aws s3 cp ./latest.txt s3://cage-build-assets-${{ env.STAGE }}/runtime/latest
+          sh ./scripts/update-runtime-version.sh ${{ env.VERSION_TAG  }}
+          aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/cli/versions
 
       - name: Cloudfront Cache Invalidation
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_STAGING }} --paths "/runtime/latest/data-plane/*" "/runtime/latest"
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_STAGING }} --paths "/runtime/latest/data-plane/*" "/runtime/latest" "/runtime/versions"

--- a/.github/workflows/scripts/update-runtime-version.sh
+++ b/.github/workflows/scripts/update-runtime-version.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e 
+
+# Script to update version json on release
+# Version json is stored in S3 and is used to determine the latest version of the runtime for each major
+# The json is structured as follows:
+# {
+# 			"latest": "2.0.4",
+# 			"versions": {
+# 				"0": { "latest": "0.0.4", "deprecationDate": "1697719181"},
+# 				"1": { "latest": "1.0.4" },
+# 				"2": { "latest": "2.0.4" }
+# 			}
+# 		}
+# The top level latest version is used to determine the latest version of the runtime overall
+
+if [ -z "$1" ]; then
+    echo "Runtime version is null. Exiting..."
+    exit 1
+fi
+
+release_version="$1"
+
+major_version=$(echo "$release_version" | cut -d '.' -f 1)
+
+echo "Release major version: $major_version"
+
+version_json=$(curl -s "https://cage-build-assets.evervault.com/runtime/versions")
+echo "Version response: $version_json"
+
+if [ $? -eq 0 ]; then
+  highest_major_version=$(echo "$version_json" | jq '.versions | keys_unsorted[] | tonumber' | sort -nr | head -1)
+  echo Highest current major version: $highest_major_version
+  if [ "$major_version" -ge "$highest_major_version" ]; then
+    #update overall latest version if release is current major
+    version_json=$(echo "$version_json" | jq --arg release_version "$release_version" '.latest = $release_version')
+  else
+    echo "Major version is less than current highest, not updating top level latest version"
+  fi
+
+  version_json=$(echo "$version_json" | jq --arg major_version "$major_version" --arg new_version "$release_version" '.versions[$major_version].latest = $new_version')
+  echo "Updated versions: $version_json"
+  echo "$version_json" > ./scripts/versions
+else
+  echo "Couldn't get versions from S3 $version_json"
+fi


### PR DESCRIPTION
# Why
We are publishing a all latest versions for each major of the cage runtime, eventually this will also be used to mange deprecation

# How
On release add the new version to the version json and publish to S3 where it will be served via cloudfront
Publish to runtime/versions
