### PR TITLE
Clear buffer after handling request

### DIFF
--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -165,7 +165,7 @@ where
                         }
                     }
                 }
-                // When we need to continue parsing the request, we will skip this line. 
+                // When we need to continue parsing the request, we will skip this line.
                 // So this will reset the buffer when the request has been consumed.
                 buffer.clear();
             }

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -88,6 +88,8 @@ where
                 let mut temp_chunk = [0; 1024];
                 let mut req = httparse::Request::new(&mut headers);
                 let chunk_size = match stream.read(&mut temp_chunk).await {
+                    // we've reached EOF
+                    Ok(chunk_size) if chunk_size == 0 => break,
                     Ok(chunk_size) => chunk_size,
                     Err(e) => {
                         log::error!("Connection read error - {e:?}");
@@ -163,6 +165,9 @@ where
                         }
                     }
                 }
+                // When we need to continue parsing the request, we will skip this line. 
+                // So this will reset the buffer when the request has been consumed.
+                buffer.clear();
             }
         });
     }

--- a/data-plane/src/server/data_plane_server.rs
+++ b/data-plane/src/server/data_plane_server.rs
@@ -89,7 +89,7 @@ where
                 let mut req = httparse::Request::new(&mut headers);
                 let chunk_size = match stream.read(&mut temp_chunk).await {
                     // we've reached EOF
-                    Ok(chunk_size) if chunk_size == 0 => break,
+                    Ok(0) => break,
                     Ok(chunk_size) => chunk_size,
                     Err(e) => {
                         log::error!("Connection read error - {e:?}");


### PR DESCRIPTION
# Why
The Cage buffer wasn't being cleared correctly after handling a request.

# How
Update check on bytes read from the socket to account for EOF, and clear the buffer on successful handling to reset the parse loop.
