### PR TITLE
feat: forward x-evervault-data-role in calls to e3

### DIFF
--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -425,9 +425,12 @@ impl AcmeCertificateRetreiver {
         raw_acme_certificate: &RawAcmeCertificate,
     ) -> Result<RawAcmeCertificate, AcmeError> {
         let e3_response: CryptoResponse = e3_client
-            .encrypt(CryptoRequest {
-                data: json!(raw_acme_certificate),
-            })
+            .encrypt(
+                CryptoRequest {
+                    data: json!(raw_acme_certificate),
+                },
+                None,
+            )
             .await?;
 
         let encrypted_acme_key_pair: RawAcmeCertificate = serde_json::from_value(e3_response.data)?;

--- a/data-plane/src/acme/key.rs
+++ b/data-plane/src/acme/key.rs
@@ -200,9 +200,12 @@ impl AcmeKeyRetreiver {
         raw_acme_key_pair: RawAcmeKeyPair,
     ) -> Result<RawAcmeKeyPair, AcmeError> {
         let e3_response: CryptoResponse = e3_client
-            .encrypt(CryptoRequest {
-                data: json!(raw_acme_key_pair),
-            })
+            .encrypt(
+                CryptoRequest {
+                    data: json!(raw_acme_key_pair),
+                },
+                None,
+            )
             .await?;
 
         let encrypted_acme_key_pair: RawAcmeKeyPair = serde_json::from_value(e3_response.data)?;

--- a/data-plane/src/base_tls_client/mod.rs
+++ b/data-plane/src/base_tls_client/mod.rs
@@ -70,9 +70,9 @@ impl BaseClient {
         // if headers have been passed, seed the request with the provided set of headers,
         // but override with required headers to avoid failed reqs.
         if let Some(headers) = headers {
-            request
-                .headers_mut()
-                .map(|header_map| *header_map = headers);
+            if let Some(req_header_map) = request.headers_mut() {
+                *req_header_map = headers
+            }
         }
         let mut request = request
             .header("Content-Type", "application/json")

--- a/data-plane/src/cert_provisioner_client/mod.rs
+++ b/data-plane/src/cert_provisioner_client/mod.rs
@@ -77,7 +77,7 @@ impl CertProvisionerClient {
 
         let response = self
             .base_client
-            .send(None, "POST", &self.uri("/cert"), body)
+            .send(None, "POST", &self.uri("/cert"), body, None)
             .await?;
 
         self.parse_response(response).await
@@ -95,7 +95,7 @@ impl CertProvisionerClient {
 
         let response = self
             .base_client
-            .send(None, "POST", &self.uri("/secrets"), body)
+            .send(None, "POST", &self.uri("/secrets"), body, None)
             .await?;
 
         self.parse_response(response).await

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -121,8 +121,16 @@ impl CryptoApi {
     }
 
     async fn encrypt(&mut self, req: Request<Body>) -> Result<Body, CryptoApiError> {
+        let data_role = req
+            .headers()
+            .get("x-evervault-data-role")
+            .and_then(|role| role.to_str().ok())
+            .map(|role_str| role_str.to_string());
         let request = self.build_request(req).await?;
-        let e3_response: CryptoResponse = self.e3_client.encrypt_with_retries(2, request).await?;
+        let e3_response: CryptoResponse = self
+            .e3_client
+            .encrypt_with_retries(2, request, data_role)
+            .await?;
         Ok(hyper::Body::from(serde_json::to_vec(&e3_response.data)?))
     }
 


### PR DESCRIPTION
# Why
With the roll out of data policies, the crypto API in Cages needs to support the feature.

# How
The Cage in enclave crypto API will forward an `x-evervault-data-role` header when set by the client
