### PR TITLE
Invalidate CF on production deployemt

### DIFF
--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -143,3 +143,7 @@ jobs:
           aws s3 cp ./latest.txt s3://cage-build-assets-${{ env.STAGE }}/runtime/latest
           sh ./scripts/update-runtime-version.sh ${{ env.VERSION_TAG  }}
           aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/runtime/versions
+
+      - name: Cloudfront Cache Invalidation
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} --paths "/runtime/latest/data-plane/*" "/runtime/latest" "/runtime/versions"        

--- a/.github/workflows/deploy-runtime-installer.yml
+++ b/.github/workflows/deploy-runtime-installer.yml
@@ -104,3 +104,7 @@ jobs:
           aws s3 cp ./latest.txt s3://cage-build-assets-${{ env.STAGE }}/installer/latest
           sh ./scripts/update-installer-version.sh ${{ env.VERSION_TAG  }} ${{ env.CHECKSUM }}
           aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/runtime/versions
+       
+      - name: Cloudfront Cache Invalidation
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} --paths "/runtime/versions"    


### PR DESCRIPTION
# Why
The CF cache isn't immediately invalidated on deployment

# How
Add invalidation
