### PR TITLE
chore: remove bootstrap variable filters from data plane

### DIFF
--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -102,7 +102,6 @@ impl Environment {
 
         let env_string = secrets
             .iter()
-            .filter(|env| env.name != "EV_CAGE_INITIALIZED")
             .map(|env| format!("export {}={}  ", env.name, env.secret))
             .collect::<Vec<String>>()
             .join("");
@@ -117,8 +116,7 @@ impl Environment {
             .append(true)
             .open("/etc/customer-env")?;
 
-        write!(file, "export EV_CAGE_INITIALIZED=true  ")?;
-        write!(file, "export EV_API_KEY=placeholder  ")?;
+        write!(file, "export EV_CAGE_INITIALIZED=true")?;
 
         Ok(())
     }


### PR DESCRIPTION
# Why
Starting in v1, the cage's provisioner will only return the environment variables as configured for the cage and will not inject any vars to mark the cage as ready

# How
Remove filters and old API Key env var