### PR TITLE
Add runtime checksum to version json object in staging

### DIFF
--- a/.github/workflows/deploy-runtime-installer.yml
+++ b/.github/workflows/deploy-runtime-installer.yml
@@ -36,7 +36,7 @@ jobs:
 
   upload-runtime-bundle-staging:
     runs-on: ubuntu-latest
-    needs: [build-runtime-bundle]
+    needs: [build-runtime-bundle, get-version]
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -57,9 +57,12 @@ jobs:
         env:
           STAGE: staging
           CHECKSUM: ${{ needs.build-runtime-bundle.outputs.checksum }}
+          VERSION_TAG: ${{ needs.get-version.outputs.version }}
         run: |
           echo "${{ env.CHECKSUM }}" > latest.txt
           aws s3 cp ./latest.txt s3://cage-build-assets-${{ env.STAGE }}/installer/latest
+          sh ./scripts/update-installer-version.sh ${{ env.VERSION_TAG  }} ${{ env.CHECKSUM }}
+          aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/runtime/versions
 
   upload-runtime-bundle-production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why
Runtime installer's checksum wasn't being pushed to staging, resulting in parse errors when trying to fetch latest

# How
Update the installer's CI to push a checksum to staging
