### PR TITLE
Add missing checkout step to runtime release workflow

### DIFF
--- a/.github/workflows/deploy-runtime-installer.yml
+++ b/.github/workflows/deploy-runtime-installer.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-runtime-bundle, get-version]
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: runtime-dependencies-${{github.sha}}.zip


### PR DESCRIPTION
# Why
Runtime installer release workflow didn't perform a git checkout before attempting to run the script

# How
Add a checkout step