### PR TITLE
Fix cages staging release workflow (#149)

### DIFF
--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -26,10 +26,30 @@ jobs:
           shared-key: "standard-cache"
       - name: Test control plane
         run: cargo test -p control-plane
+  
+  get-release-semver:
+    needs: [last_test]
+    runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.get-version.outputs.semver }}
+      semver-sha: ${{ steps.get-version.outputs.semver-sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Parse semver from cargo.toml
+        id: get-version
+        run: |
+          SHA_SUFFIX=${GITHUB_SHA::6}
+          SEMVER=$(cargo metadata --no-deps | jq -r ".packages[] | select(.name == \"control-plane\") | .version")
+          echo "Full semver: ${SEMVER}, appending suffix: ${SHA_SUFFIX}"
+          echo "semver=${SEMVER}" >> $GITHUB_OUTPUT
+          echo "semver-sha=${SEMVER}-${SHA_SUFFIX}" >> $GITHUB_OUTPUT
 
   deploy_control_plane_image_with_egress:
     runs-on: ubuntu-latest
-    needs: last_test
+    needs: [last_test, get-release-semver]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,11 +60,6 @@ jobs:
           cmd: cargo build -p control-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
           RUSTFLAGS: "--cfg staging"
-      - name: Get control plane version
-        id: get_version
-        run: |
-          VERSION=$(cargo metadata | jq -r ".packages[] | select(.name == \"control-plane\") | .version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Staging AWS Credentials
@@ -62,7 +77,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
-          SEMVER: ${{ steps.get_version.outputs.version }}
+          SEMVER: ${{ needs.get-release-semver.outputs.semver }}
         run: |
           docker build -f ./control-plane/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$SEMVER --pull --no-cache .
       - name: Push control plane image to Amazon ECR
@@ -71,15 +86,14 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
-          SEMVER: ${{ steps.get_version.outputs.version }}
+          SEMVER: ${{ needs.get-release-semver.outputs.semver }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-enabled-$SEMVER
 
   deploy_control_plane_image_without_egress:
     runs-on: ubuntu-latest
-    needs: last_test
-
+    needs: [last_test, get-release-semver]
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
@@ -89,11 +103,6 @@ jobs:
           cmd: cargo build -p control-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
           RUSTFLAGS: "--cfg staging"
-      - name: Get control plane version
-        id: get_version
-        run: |
-          VERSION=$(cargo metadata | jq -r ".packages[] | select(.name == \"control-plane\") | .version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Staging AWS Credentials
@@ -111,7 +120,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
-          SEMVER: ${{ steps.get_version.outputs.version }}
+          SEMVER: ${{ needs.get-release-semver.outputs.semver }}
         run: |
           docker build -f ./control-plane/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$SEMVER --pull --no-cache .
       - name: Push control plane image to Amazon ECR
@@ -120,7 +129,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: evervault/control-plane
           IMAGE_TAG: ${{ github.sha }}
-          SEMVER: ${{ steps.get_version.outputs.version }}
+          SEMVER: ${{ needs.get-release-semver.outputs.semver }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:egress-disabled-$SEMVER

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -15,8 +15,28 @@ env:
   STAGE: staging
 
 jobs:
+  get-release-semver:
+    runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.get-version.outputs.semver }}
+      semver-sha: ${{ steps.get-version.outputs.semver-sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Parse semver from cargo.toml
+        id: get-version
+        run: |
+          SHA_SUFFIX=${GITHUB_SHA::6}
+          SEMVER=$(cargo metadata --no-deps | jq -r ".packages[] | select(.name == \"data-plane\") | .version")
+          echo "Full semver: ${SEMVER}, appending suffix: ${SHA_SUFFIX}"
+          echo "semver=${SEMVER}" >> $GITHUB_OUTPUT
+          echo "semver-sha=${SEMVER}-${SHA_SUFFIX}" >> $GITHUB_OUTPUT
+
   deploy-data-plane-binary:
     runs-on: ubuntu-latest
+    needs: [get-release-semver]
     steps:
       - uses: actions/checkout@v2
 
@@ -41,7 +61,7 @@ jobs:
 
       - name: Upload data-plane to S3 (egress enabled, tls termination disabled)
         env:
-          VERSION_TAG: ${{ github.sha }}
+          VERSION_TAG: ${{ needs.get-release-semver.outputs.semver-sha }}
           FEATURE_LABEL: egress-enabled/tls-termination-disabled
         run: |
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
@@ -57,7 +77,7 @@ jobs:
 
       - name: Upload data-plane to S3 (egress enabled, tls termination enabled)
         env:
-          VERSION_TAG: ${{ github.sha }}
+          VERSION_TAG: ${{ needs.get-release-semver.outputs.semver-sha }}
           FEATURE_LABEL: egress-enabled/tls-termination-enabled
         run: |
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
@@ -73,7 +93,7 @@ jobs:
 
       - name: Upload data-plane to S3 (egress disabled, tls termination disabled)
         env:
-          VERSION_TAG: ${{ github.sha }}
+          VERSION_TAG: ${{ needs.get-release-semver.outputs.semver-sha }}
           FEATURE_LABEL: egress-disabled/tls-termination-disabled
         run: |
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
@@ -89,7 +109,7 @@ jobs:
 
       - name: Upload data-plane to S3 (egress disabled, tls termination enabled)
         env:
-          VERSION_TAG: ${{ github.sha }}
+          VERSION_TAG: ${{ needs.get-release-semver.outputs.semver-sha }}
           FEATURE_LABEL: egress-disabled/tls-termination-enabled
         run: |
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
@@ -97,10 +117,12 @@ jobs:
 
       - name: Upload version tag to latest file
         env:
-          VERSION_TAG: ${{ github.sha }}
+          VERSION_TAG: ${{ needs.get-release-semver.outputs.semver-sha }}
         run: |
           echo "{ \"data-plane\": \"${{ env.VERSION_TAG }}\" }" > latest.txt
           aws s3 cp ./latest.txt s3://cage-build-assets-${{ env.STAGE }}/runtime/latest
+          CAGE_BUILD_ASSETS_HOSTNAME=cage-build-assets.evervault.io sh ./scripts/update-runtime-version.sh ${{ env.VERSION_TAG }}
+          aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/runtime/versions
 
       - name: Cloudfront Cache Invalidation
         run: |

--- a/scripts/update-runtime-version.sh
+++ b/scripts/update-runtime-version.sh
@@ -25,7 +25,7 @@ major_version=$(echo "$release_version" | cut -d '.' -f 1)
 
 echo "Release major version: $major_version"
 
-version_json=$(curl -s "https://cage-build-assets.evervault.com/runtime/versions")
+version_json=$(curl -s "https://${CAGE_BUILD_ASSETS_HOSTNAME:-cage-build-assets.evervault.com}/runtime/versions")
 echo "Version response: $version_json"
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Backporting changes to v0 release branch.

* update data plane staging release flow to be compatible with new semver flows

* chore: update staging release ci to use current semver suffixed with git sha

* chore: update runtime-version script to accept build assets hostname as an env var
