### PR TITLE
chore: update ci actions to trigger for changes to release/v* branch

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v0.*.*"
 
 name: Deploy new control plane image to production
 env:

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -8,6 +8,7 @@ on:
       - scripts/health-check.sh
     branches:
       - main
+      - release/v*
 name: Deploy new control plane image
 env:
   LINUX_TARGET: x86_64-unknown-linux-musl

--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -3,7 +3,7 @@ name: Release data-plane binary production
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v0.*.*"
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -8,6 +8,7 @@ on:
       - shared/**
     branches:
       - main
+      - release/v*
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/deploy-runtime-installer.yml
+++ b/.github/workflows/deploy-runtime-installer.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "installer/v*.*.*"
+      - "installer/v0.*.*"
 
 name: Build and deploy runtime installer bundle
 jobs:

--- a/.github/workflows/test-runtime-builder.yml
+++ b/.github/workflows/test-runtime-builder.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     branches:
       - main
+      - release/v*
     paths:
       - installer/**
       - .github/workflows/test-runtime-builder.yml


### PR DESCRIPTION
# Why
CI on release/v0 branch wasn't firing for changes because branch triggers were wrong

# How
- Update to trigger on push to release/v0
- Restrict release workflows to only accept tags with the frozen major version (0)
