### PR TITLE
chore: bump control plane and data plane to new major version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "control-plane"
-version = "0.0.43"
+version = "1.0.0-beta"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1047,7 +1047,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "data-plane"
-version = "0.0.43"
+version = "1.0.0-beta"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control-plane"
-version = "0.0.43"
+version = "1.0.0-beta"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-plane"
-version = "0.0.43"
+version = "1.0.0-beta"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 


### PR DESCRIPTION
# Why
We're currently working towards the next major release of Cages. To avoid conflicting releases between v0 and v1 in our staging environment, we need to migrate the control plane and data plane crates to v1. 

# How
Update control plane and data plane packages to have new version `1.0.0-beta`
