### PR TITLE
CI is using an old version of rust, update to 1.73.0 stable

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
       - name: Build control plane
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p control-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
       - name: Move control-plane binary to root
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
       - name: Build control plane
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p control-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
       - name: Move control-plane binary to root

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
       - name: Build control plane
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p control-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
       - name: Build control plane
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p control-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:

--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build data-plane (egress enabled, tls termination enabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
 
@@ -53,7 +53,7 @@ jobs:
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
 
       - name: Build data-plane (egress enabled, tls termination disabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --no-default-features --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
 
@@ -65,7 +65,7 @@ jobs:
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
 
       - name: Build data-plane (egress disabled, tls termination enabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
 
@@ -77,7 +77,7 @@ jobs:
           aws s3 cp ./target/${{ env.LINUX_TARGET }}/release/data-plane s3://cage-build-assets-${{ env.STAGE }}/runtime/${{ env.VERSION_TAG }}/data-plane/${{ env.FEATURE_LABEL }}
 
       - name: Build data-plane (egress disabled, tls termination disabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --no-default-features --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
 

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Egress Enabled, TLS Termination Disabled
       - name: Build data-plane (egress enabled, tls termination disabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --no-default-features --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
@@ -69,7 +69,7 @@ jobs:
 
       # Egress Enabled, TLS Termination Enabled
       - name: Build data-plane (egress enabled, tls termination enabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
@@ -85,7 +85,7 @@ jobs:
 
       # Egress Disabled, TLS Termination Disabled
       - name: Build data-plane (egress disabled, tls termination disabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --no-default-features --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:
@@ -101,7 +101,7 @@ jobs:
 
       # Egress Disabled, TLS Termination Enabled
       - name: Build data-plane (egress disabled, tls termination enabled)
-        uses: evervault/cargo-static-build@master
+        uses: evervault/cargo-static-build@v1.73.0-stable
         with:
           cmd: cargo build -p data-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
         env:


### PR DESCRIPTION
# Why
Latest changes failed to compile in CI as the static build action was using an old version of rustc

# How
Pin rust version to v1.73.0 stable
