### PR TITLE
Decrypt error set the wrong content length in the response

### DIFF
--- a/data-plane/src/server/layers/decrypt.rs
+++ b/data-plane/src/server/layers/decrypt.rs
@@ -39,7 +39,7 @@ impl std::convert::From<DecryptError> for Response<Body> {
         .to_string();
         Response::builder()
             .status(err.to_status())
-            .header("content-length", msg.len())
+            .header("content-length", body.len())
             .body(body.into())
             .expect("Failed to build auth error to response")
     }


### PR DESCRIPTION
# Why
Content length on the incoming-request decrypt layer's error response was wrong, causing the error message to be truncated.

# How

Use serialized response's length