### PR TITLE
Update attestation uri check to compare against path

### DIFF
--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -85,7 +85,7 @@ where
 }
 
 fn is_attestation_request(req: &Request<Body>) -> bool {
-    req.uri().path().ends_with("/.well-known/attestation")
+    req.uri().path() == "/.well-known/attestation"
 }
 
 #[cfg(test)]

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -85,7 +85,7 @@ where
 }
 
 fn is_attestation_request(req: &Request<Body>) -> bool {
-    req.uri() == "/.well-known/attestation"
+    req.uri().path().ends_with("/.well-known/attestation")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Why
Attestation check is comparing against the URI, which isn't matching.

# How
Use the path getter to compare against
