### PR TITLE
[SPE-986] Expand trusted cert hostnames to handle the new enclave domain

### DIFF
--- a/control-plane/src/config_server.rs
+++ b/control-plane/src/config_server.rs
@@ -430,14 +430,17 @@ fn valid_order_identifiers(
 ) -> bool {
     let trusted_base_domains = configuration::get_trusted_cert_base_domains();
 
-    let valid_domains: Vec<String> = trusted_base_domains.iter().map(|base_domain| {
-        format!(
-            "{}.{}.{}",
-            &cage_context.cage_name,
-            &cage_context.hyphenated_app_uuid(),
-            base_domain
-        )
-    }).collect();
+    let valid_domains: Vec<String> = trusted_base_domains
+        .iter()
+        .map(|base_domain| {
+            format!(
+                "{}.{}.{}",
+                &cage_context.cage_name,
+                &cage_context.hyphenated_app_uuid(),
+                base_domain
+            )
+        })
+        .collect();
 
     payload
         .identifiers

--- a/control-plane/src/config_server.rs
+++ b/control-plane/src/config_server.rs
@@ -334,10 +334,9 @@ async fn handle_acme_signing_request(
     acme_account_details: AcmeAccountDetails,
     cage_context: configuration::CageContext,
 ) -> Response<Body> {
-    log::info!("Received ACME signing request in config server");
     match sign_acme_payload(req, acme_account_details, cage_context).await {
         Ok(response) => response,
-        Err(_) => build_error_response("Failed to sign JWS request".to_string()),
+        Err(err) => build_error_response(format!("Failed to sign JWS request. Err: {}", err)),
     }
 }
 
@@ -368,6 +367,7 @@ async fn sign_acme_payload(
                 let order_payload: NewOrderPayload = serde_json::from_str(&jws_request.payload)?;
 
                 if !valid_order_identifiers(order_payload, cage_context) {
+                    log::error!("[ACME] Domain for order was not for valid Evervault Enclave domain. Rejecting signing request.");
                     return Ok(build_bad_request_response());
                 }
             };
@@ -392,7 +392,7 @@ async fn sign_acme_payload(
                         .map_err(ServerError::HyperHttp)
                 }
                 Err(err) => {
-                    log::error!("Failed to sign request: {}", err);
+                    log::error!("[ACME] Failed to sign request: {}", err);
                     Ok(build_error_response(
                         "Failed to sign JWS request".to_string(),
                     ))
@@ -406,10 +406,9 @@ async fn sign_acme_payload(
 }
 
 async fn handle_acme_jwk_request(acme_account_details: AcmeAccountDetails) -> Response<Body> {
-    log::info!("Recieved ACME JWK request in config server");
     match get_acme_jwk(acme_account_details).await {
         Ok(response) => response,
-        Err(_) => build_error_response("Failed to get JWK".to_string()),
+        Err(err) => build_error_response(format!("Failed to get JWK. Err: {}", err)),
     }
 }
 
@@ -429,19 +428,21 @@ fn valid_order_identifiers(
     payload: NewOrderPayload,
     cage_context: configuration::CageContext,
 ) -> bool {
-    let cage_base_domain = configuration::get_trusted_cert_base_domain();
+    let trusted_base_domains = configuration::get_trusted_cert_base_domains();
 
-    let cage_domain = format!(
-        "{}.{}.{}",
-        &cage_context.cage_name,
-        &cage_context.hyphenated_app_uuid(),
-        cage_base_domain
-    );
+    let valid_domains: Vec<String> = trusted_base_domains.iter().map(|base_domain| {
+        format!(
+            "{}.{}.{}",
+            &cage_context.cage_name,
+            &cage_context.hyphenated_app_uuid(),
+            base_domain
+        )
+    }).collect();
 
     payload
         .identifiers
         .into_iter()
-        .all(|identifier| identifier.value == cage_domain)
+        .all(|identifier| valid_domains.contains(&identifier.value))
 }
 
 fn build_success_response() -> Response<Body> {

--- a/control-plane/src/configuration.rs
+++ b/control-plane/src/configuration.rs
@@ -166,9 +166,15 @@ pub fn get_acme_hmac_key_id() -> String {
 
 pub fn get_trusted_cert_base_domains() -> Vec<String> {
     #[cfg(not(staging))]
-    let cage_base_domains = vec!["cage.evervault.com".to_string(), "enclave.evervault.com".to_string()];
+    let cage_base_domains = vec![
+        "cage.evervault.com".to_string(),
+        "enclave.evervault.com".to_string(),
+    ];
     #[cfg(staging)]
-    let cage_base_domains = vec!["cage.evervault.dev".to_string(), "enclave.evervault.dev".to_string()];
+    let cage_base_domains = vec![
+        "cage.evervault.dev".to_string(),
+        "enclave.evervault.dev".to_string(),
+    ];
 
     cage_base_domains
 }

--- a/control-plane/src/configuration.rs
+++ b/control-plane/src/configuration.rs
@@ -164,11 +164,11 @@ pub fn get_acme_hmac_key_id() -> String {
     std::env::var("ACME_ACCOUNT_HMAC_KEY_ID").expect("ACME_ACCOUNT_HMAC_KEY_ID is not set in env")
 }
 
-pub fn get_trusted_cert_base_domain() -> String {
+pub fn get_trusted_cert_base_domains() -> Vec<String> {
     #[cfg(not(staging))]
-    let cage_base_domain = "cage.evervault.com";
+    let cage_base_domains = vec!["cage.evervault.com".to_string(), "enclave.evervault.com".to_string()];
     #[cfg(staging)]
-    let cage_base_domain = "cage.evervault.dev";
+    let cage_base_domains = vec!["cage.evervault.dev".to_string(), "enclave.evervault.dev".to_string()];
 
-    cage_base_domain.into()
+    cage_base_domains
 }

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -357,7 +357,10 @@ impl AcmeCertificateRetreiver {
         log::info!("[ACME] Fetching authorizations needed for order.");
         let authorizations = order.authorizations().await?;
 
-        log::info!("[ACME] {} authorizations needed. Storing challenges.", authorizations.len());
+        log::info!(
+            "[ACME] {} authorizations needed. Storing challenges.",
+            authorizations.len()
+        );
         for auth in authorizations {
             let challenge = auth
                 .get_challenge("http-01")
@@ -392,7 +395,9 @@ impl AcmeCertificateRetreiver {
             auth.wait_done(Duration::from_secs(5), 5).await?;
         }
 
-        log::info!("[ACME] All authorizations validated. Continuing polling order to check if ready.");
+        log::info!(
+            "[ACME] All authorizations validated. Continuing polling order to check if ready."
+        );
 
         let order_ready = order.wait_ready(Duration::from_secs(5), 5).await?;
 
@@ -400,10 +405,8 @@ impl AcmeCertificateRetreiver {
 
         let order_finalized = order_ready.finalize(key).await?;
 
-        let order_complete = order_finalized
-            .wait_done(Duration::from_secs(5), 5)
-            .await?;
-        
+        let order_complete = order_finalized.wait_done(Duration::from_secs(5), 5).await?;
+
         log::info!("[ACME] Order is complete. Downloading certficate.");
 
         let cert_chain = order_complete

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -255,7 +255,7 @@ impl AcmeCertificateRetreiver {
                     Some(decrypted_certificate.to_certified_key(x509s, key)).transpose()
                 }
                 RenewalStrategy::SyncRenewal => {
-                    log::info!("[ACME] Certificate expires in the comming week. Should be renewed synchronously");
+                    log::info!("[ACME] Certificate expires in the coming week. Should be renewed synchronously");
                     Ok(None)
                 }
                 RenewalStrategy::NoRenewal => {
@@ -287,8 +287,8 @@ impl AcmeCertificateRetreiver {
             self.config_client.clone(),
         );
         if certificate_lock.write_and_check_persisted().await? {
-            let cert_domain = cage_context.get_trusted_cert_name();
-            let raw_acme_certificate = self.order_certificate(cert_domain, key.clone()).await?;
+            let cert_domains = cage_context.get_trusted_cert_domains();
+            let raw_acme_certificate = self.order_certificate(cert_domains, key.clone()).await?;
 
             let encrypted_raw_certificate =
                 Self::encrypt_certificate(&self.e3_client, &raw_acme_certificate).await?;
@@ -328,13 +328,14 @@ impl AcmeCertificateRetreiver {
     //Use all the acme libraries to order cert
     async fn order_certificate(
         &mut self,
-        domain: String,
+        domains: Vec<String>,
         key: PKey<Private>,
     ) -> Result<RawAcmeCertificate, AcmeError> {
         if self.acme_account.is_none() {
             self.acme_account = Some(self.init_acme_account().await?);
         };
 
+        log::info!("[ACME] Initializing acme account.");
         let acme_account = match self.acme_account {
             Some(ref acme_account) => acme_account.clone(),
             None => {
@@ -346,11 +347,17 @@ impl AcmeCertificateRetreiver {
 
         let mut order_builder = OrderBuilder::new(acme_account);
 
-        order_builder.add_dns_identifier(domain);
+        for domain in domains.iter() {
+            order_builder.add_dns_identifier(domain.to_string());
+        }
 
+        log::info!("[ACME] Creating order for trusted cert.");
         let order = order_builder.build().await?;
+
+        log::info!("[ACME] Fetching authorizations needed for order.");
         let authorizations = order.authorizations().await?;
 
+        log::info!("[ACME] {} authorizations needed. Storing challenges.", authorizations.len());
         for auth in authorizations {
             let challenge = auth
                 .get_challenge("http-01")
@@ -385,13 +392,19 @@ impl AcmeCertificateRetreiver {
             auth.wait_done(Duration::from_secs(5), 5).await?;
         }
 
+        log::info!("[ACME] All authorizations validated. Continuing polling order to check if ready.");
+
         let order_ready = order.wait_ready(Duration::from_secs(5), 5).await?;
+
+        log::info!("[ACME] Order is ready. Finalizing order.");
+
         let order_finalized = order_ready.finalize(key).await?;
 
         let order_complete = order_finalized
             .wait_done(Duration::from_secs(5), 5)
-            .await
-            .unwrap();
+            .await?;
+        
+        log::info!("[ACME] Order is complete. Downloading certficate.");
 
         let cert_chain = order_complete
             .certificate()
@@ -400,7 +413,7 @@ impl AcmeCertificateRetreiver {
                 "Certificate not found in completed order".into(),
             ))?;
 
-        log::info!("Certificate received from ACME provider: {:?}", cert_chain);
+        log::info!("[ACME] Certificate received!");
 
         RawAcmeCertificate::from_x509s(cert_chain)
     }

--- a/data-plane/src/config_client.rs
+++ b/data-plane/src/config_client.rs
@@ -163,18 +163,20 @@ impl ConfigClient {
             .send(ConfigServerPath::AcmeSign, "GET", payload)
             .await?;
 
-        if response.status() == StatusCode::OK {
+        let response_status = response.status();
+        if response_status == StatusCode::OK {
             let result: JwsResponse = self.parse_response(response).await?;
             Ok(result)
         } else {
-            log::error!(
-                "Error sending jws request to control plane. Response Code: {}",
-                response.status()
+            let response_body = self.parse_response_body_to_string(response).await?;
+            let err_msg = format!(
+                "Error sending jws request to control plane. Response Code: {}. Msg: {}",
+                response_status,
+                response_body
             );
-            Err(Error::ConfigServer(
-                "Invalid Response code returned when sending jws request to control plane"
-                    .to_string(),
-            ))
+
+            log::error!("{}", err_msg);
+            Err(Error::ConfigServer(err_msg))
         }
     }
 
@@ -183,18 +185,20 @@ impl ConfigClient {
             .send(ConfigServerPath::AcmeJWK, "POST", Body::empty())
             .await?;
 
-        if response.status() == StatusCode::OK {
+        let response_status = response.status();
+        if response_status == StatusCode::OK {
             let result: JwkResponse = self.parse_response(response).await?;
             Ok(result)
         } else {
-            log::error!(
-                "Error sending jwk request to control plane. Response Code: {}",
-                response.status()
+            let response_body = self.parse_response_body_to_string(response).await?;
+            let err_msg = format!(
+                "Error sending jwk request to control plane. Response Code: {}. Msg: {}",
+                response_status,
+                response_body
             );
-            Err(Error::ConfigServer(
-                "Invalid Response code returned when sending jwk request to control plane"
-                    .to_string(),
-            ))
+
+            log::error!("{}", err_msg);
+            Err(Error::ConfigServer(err_msg))
         }
     }
 
@@ -207,6 +211,11 @@ impl ConfigClient {
                 "Error parsing response from config server. Error: {err:?}"
             ))
         })
+    }
+
+    async fn parse_response_body_to_string(&self, res: Response<Body>) -> Result<String> {
+        let body_bytes = hyper::body::to_bytes(res.into_body()).await?;
+        String::from_utf8(body_bytes.to_vec()).map_err(Error::FromUtf8Error)
     }
 
     async fn base_get_object(&self, key: String) -> Result<Option<GetObjectResponse>> {

--- a/data-plane/src/config_client.rs
+++ b/data-plane/src/config_client.rs
@@ -171,8 +171,7 @@ impl ConfigClient {
             let response_body = self.parse_response_body_to_string(response).await?;
             let err_msg = format!(
                 "Error sending jws request to control plane. Response Code: {}. Msg: {}",
-                response_status,
-                response_body
+                response_status, response_body
             );
 
             log::error!("{}", err_msg);
@@ -193,8 +192,7 @@ impl ConfigClient {
             let response_body = self.parse_response_body_to_string(response).await?;
             let err_msg = format!(
                 "Error sending jwk request to control plane. Response Code: {}. Msg: {}",
-                response_status,
-                response_body
+                response_status, response_body
             );
 
             log::error!("{}", err_msg);

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -77,7 +77,7 @@ pub enum Error {
     #[error("Request timed out in data plane after {0} seconds")]
     RequestTimeout(usize),
     #[error("FromUtf8Error")]
-    FromUtf8Error(#[from] std::string::FromUtf8Error)
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/error.rs
+++ b/data-plane/src/error.rs
@@ -76,6 +76,8 @@ pub enum Error {
     AttestationRequestError(String),
     #[error("Request timed out in data plane after {0} seconds")]
     RequestTimeout(usize),
+    #[error("FromUtf8Error")]
+    FromUtf8Error(#[from] std::string::FromUtf8Error)
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -122,10 +122,10 @@ impl CageContext {
 
     pub fn get_trusted_cert_domains(&self) -> Vec<String> {
         #[cfg(not(staging))]
-        let base_domains = vec!["cage.evervault.com", "enclave.evervault.com"];
+        let base_domains = ["cage.evervault.com", "enclave.evervault.com"];
 
         #[cfg(staging)]
-        let base_domains = vec!["cage.evervault.dev", "enclave.evervault.dev"];
+        let base_domains = ["cage.evervault.dev", "enclave.evervault.dev"];
 
         base_domains
             .iter()

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -120,22 +120,21 @@ impl CageContext {
         )
     }
 
-    #[cfg(not(staging))]
-    pub fn get_trusted_cert_name(&self) -> String {
-        format!(
-            "{}.{}.cage.evervault.com",
-            &self.cage_name,
-            &self.hyphenated_app_uuid()
-        )
-    }
+    pub fn get_trusted_cert_domains(&self) -> Vec<String> {
+        #[cfg(not(staging))]
+        let base_domains = vec!["cage.evervault.com", "enclave.evervault.com"];
 
-    #[cfg(staging)]
-    pub fn get_trusted_cert_name(&self) -> String {
-        format!(
-            "{}.{}.cage.evervault.dev",
-            &self.cage_name,
-            &self.hyphenated_app_uuid()
-        )
+        #[cfg(staging)]
+        let base_domains = vec!["cage.evervault.dev", "enclave.evervault.dev"];
+
+        base_domains.iter().map(|domain| {
+            format!(            
+                "{}.{}.{}",
+                &self.cage_name,
+                &self.hyphenated_app_uuid(),
+                domain
+            )
+        }).collect()
     }
 
     pub fn get_cert_names(&self) -> Vec<String> {

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -127,14 +127,17 @@ impl CageContext {
         #[cfg(staging)]
         let base_domains = vec!["cage.evervault.dev", "enclave.evervault.dev"];
 
-        base_domains.iter().map(|domain| {
-            format!(            
-                "{}.{}.{}",
-                &self.cage_name,
-                &self.hyphenated_app_uuid(),
-                domain
-            )
-        }).collect()
+        base_domains
+            .iter()
+            .map(|domain| {
+                format!(
+                    "{}.{}.{}",
+                    &self.cage_name,
+                    &self.hyphenated_app_uuid(),
+                    domain
+                )
+            })
+            .collect()
     }
 
     pub fn get_cert_names(&self) -> Vec<String> {


### PR DESCRIPTION
# Why
We need to provision a trusted cert for the new enclave domain.

# How
Updated the acme flow to order certs for two domains:
* `cage-name.app-uuid.cage.evervault.com`
* `cage-name.app-uuid.enclave.evervault.com`

The acme process already handles multiple authorizations so it should automatically check that each domain is validated. The check in the control plane to check that we're only ordering ev enclave certs has also being updated.

I also did some small refactoring and logging for acme: 
I updated error handling for the JWS requests so that the error message is actually logged, rather that just the status code. We can do an overhaul to the whole config server to return error messages correctly but I didn't do that here as it was out of the scope of the PR.
I added logs to the top level acme order method to give a general idea of the state of an order.