### PR TITLE
Disable release logging in staging

### DIFF
--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build control plane
         uses: evervault/cargo-static-build@v1.73.0-stable
         with:
-          cmd: cargo build -p control-plane --features enclave,network_egress,release_logging --release --target ${{ env.LINUX_TARGET }}
+          cmd: cargo build -p control-plane --features enclave,network_egress --release --target ${{ env.LINUX_TARGET }}
         env:
           RUSTFLAGS: "--cfg staging"
       - name: Move control-plane binary to root
@@ -100,7 +100,7 @@ jobs:
       - name: Build control plane
         uses: evervault/cargo-static-build@v1.73.0-stable
         with:
-          cmd: cargo build -p control-plane --features enclave,release_logging --release --target ${{ env.LINUX_TARGET }}
+          cmd: cargo build -p control-plane --features enclave --release --target ${{ env.LINUX_TARGET }}
         env:
           RUSTFLAGS: "--cfg staging"
       - name: Move control-plane binary to root


### PR DESCRIPTION
# Why
We should be able to look at debug logs in staging

# How
Remove feature flag on staging build
