### PR TITLE
[SPE-987] Update cert resolver to use trusted cert for enclave domain

### DIFF
--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -134,13 +134,10 @@ impl AttestableCertResolver {
     pub(crate) fn is_trusted_cert_domain(received_servername: Option<&str>) -> bool {
         match received_servername {
             Some(servername) => {
-                let split_hostname: Vec<&str> = servername.split('.').collect();
-                let subdomains_total = split_hostname.len();
-
-                split_hostname
-                    .get(subdomains_total - 3) //Second from the end
-                    .map(|specific_subdomain| specific_subdomain == &"cage")
-                    .unwrap_or(false)
+                servername.split('.')
+                    .rev() 
+                    .nth(1)
+                    .map_or(false, |subdomain| ["cage", "enclave"].contains(&subdomain))
             }
             None => false,
         }
@@ -560,6 +557,12 @@ mod tests {
     #[test]
     fn test_trusted_cert_used_with_trusted_hostname() {
         let server_name = Some("wicked_cage.app_123543.cage.evervault.com".to_string());
+        test_trusted_cert_with_hostname(server_name, true);
+    }
+    
+    #[test]
+    fn test_trusted_cert_used_with_trusted_enclave_hostname() {
+        let server_name = Some("wicked_cage.app_123543.enclave.evervault.com".to_string());
         test_trusted_cert_with_hostname(server_name, true);
     }
 

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -136,8 +136,12 @@ impl AttestableCertResolver {
             Some(servername) => servername
                 .split('.')
                 .rev()
-                .nth(1)
-                .map_or(false, |subdomain| ["cage", "enclave"].contains(&subdomain)),
+                .nth(2)
+                .map_or(false, |subdomain| {
+                    println!("subdomain: {}", subdomain);
+                    ["cage", "enclave"].contains(&subdomain)
+                }),
+
             None => false,
         }
     }

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -137,9 +137,7 @@ impl AttestableCertResolver {
                 .split('.')
                 .rev()
                 .nth(2)
-                .map_or(false, |subdomain| {
-                    ["cage", "enclave"].contains(&subdomain)
-                }),
+                .map_or(false, |subdomain| ["cage", "enclave"].contains(&subdomain)),
 
             None => false,
         }

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -138,7 +138,6 @@ impl AttestableCertResolver {
                 .rev()
                 .nth(2)
                 .map_or(false, |subdomain| {
-                    println!("subdomain: {}", subdomain);
                     ["cage", "enclave"].contains(&subdomain)
                 }),
 

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -133,12 +133,11 @@ impl AttestableCertResolver {
     //[cage-name].[cage-uuid].cage.evervault.[com|dev]
     pub(crate) fn is_trusted_cert_domain(received_servername: Option<&str>) -> bool {
         match received_servername {
-            Some(servername) => {
-                servername.split('.')
-                    .rev() 
-                    .nth(1)
-                    .map_or(false, |subdomain| ["cage", "enclave"].contains(&subdomain))
-            }
+            Some(servername) => servername
+                .split('.')
+                .rev()
+                .nth(1)
+                .map_or(false, |subdomain| ["cage", "enclave"].contains(&subdomain)),
             None => false,
         }
     }
@@ -559,7 +558,7 @@ mod tests {
         let server_name = Some("wicked_cage.app_123543.cage.evervault.com".to_string());
         test_trusted_cert_with_hostname(server_name, true);
     }
-    
+
     #[test]
     fn test_trusted_cert_used_with_trusted_enclave_hostname() {
         let server_name = Some("wicked_cage.app_123543.enclave.evervault.com".to_string());


### PR DESCRIPTION
# Why
When a request is made for `...enclave.evervault.com/dev`, we should serve the trusted cert.

# How
Update check for serving trusted cert in resolver to include `enclave` as well as cage
