### PR TITLE
Remove cage from initialisation flag

### DIFF
--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -116,7 +116,7 @@ impl Environment {
             .append(true)
             .open("/etc/customer-env")?;
 
-        write!(file, "export EV_CAGE_INITIALIZED=true")?;
+        write!(file, "export EV_INITIALIZED=true")?;
 
         Ok(())
     }

--- a/data-plane/src/health/initialized.rs
+++ b/data-plane/src/health/initialized.rs
@@ -10,6 +10,6 @@ impl InitializedHealthcheck for EnclaveEnvInitialized {
 
     fn is_initialized(&self) -> Result<bool, Self::Error> {
         let contents = std::fs::read_to_string("/etc/customer-env")?;
-        Ok(contents.contains("EV_CAGE_INITIALIZED"))
+        Ok(contents.contains("EV_INITIALIZED"))
     }
 }

--- a/e2e-tests/mockCertProvisionerApi.js
+++ b/e2e-tests/mockCertProvisionerApi.js
@@ -80,7 +80,7 @@ tlsApp.post('/cert', async (req, res) => {
     var result = {
       intermediate_cert: ca_cert,
       key_pair: ca_key_pair,
-      secrets: [{name: "EV_CAGE_INITIALIZED", secret: "true"}, {name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}],
+      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}],
       context: {team_uuid: "team_123", cage_uuid: "cage_123", app_uuid: "app_12345678", cage_name: "test-cage"},
     };
     res.status(200)
@@ -96,7 +96,7 @@ tlsApp.post('/secrets', async (req, res) => {
     
     var result = {
       context: {team_uuid: "team_123", cage_uuid: "cage_123", app_uuid: "app_12345678", cage_name: "test-cage"},
-      secrets: [{name: "EV_CAGE_INITIALIZED", secret: "true"}, {name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}]
+      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}]
     };
     res.status(200)
     res.send(result) 

--- a/e2e-tests/scripts/start_customer_process
+++ b/e2e-tests/scripts/start_customer_process
@@ -2,7 +2,7 @@
 CUSTOMER_PROCESS="$1"
 
 # Wait for environment to be placed in env faile before starting process
-while ! grep -q "EV_CAGE_INITIALIZED" /etc/customer-env;
+while ! grep -q "EV_INITIALIZED" /etc/customer-env;
 do 
     echo "Environment not ready, sleeping user process for one second";
     sleep 1;


### PR DESCRIPTION
# Why
Remove `cage` from the init flag so it can be removed in V1 cli

# How
Remove `cage`
