### PR TITLE
Correct content type header for 401 response

### DIFF
--- a/data-plane/src/server/layers/auth.rs
+++ b/data-plane/src/server/layers/auth.rs
@@ -45,7 +45,7 @@ impl std::convert::From<AuthError> for Response<Body> {
         .to_string();
         Response::builder()
             .status(err.to_status())
-            .header("content-type", "appliction/json")
+            .header("content-type", "application/json")
             .header("content-length", body.len())
             .body(body.into())
             .expect("Failed to build auth error to response")


### PR DESCRIPTION
# Why
Content type header has a typo in it which prevents the response from rendering in the browser

# How
Correct typo.
