### PR TITLE
Update egress IP for local testing

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -22,7 +22,7 @@ pub const ENCLAVE_IP: &str = "172.20.0.7";
 pub const PARENT_IP: &str = "172.20.0.8";
 
 #[cfg(not(feature = "enclave"))]
-pub const TEST_EGRESS_IP: &str = "172.64.101.22";
+pub const TEST_EGRESS_IP: &str = "188.114.97.2";
 
 pub mod acme;
 pub mod logging;


### PR DESCRIPTION
# Why
An IP is hardcoded for local testing because `SO_ORIGINAL_DST` isn't set for docker on mac. We should look it up in the tests or use our own IP going forward because it has changed

# How
Update the IP for now to fix e2es
